### PR TITLE
feat: Docker setup with PostgreSQL pgvector + backend node

### DIFF
--- a/Backend/.dockerignore
+++ b/Backend/.dockerignore
@@ -1,0 +1,7 @@
+node_modules
+dist
+.env
+.env.*
+!.env.example
+*.log
+.git

--- a/Backend/Dockerfile
+++ b/Backend/Dockerfile
@@ -1,0 +1,20 @@
+# ── ReservAqui Backend ─────────────────────────────────────────
+# Build: docker compose build
+# Run:   docker compose up
+# ───────────────────────────────────────────────────────────────
+
+FROM node:20-alpine
+
+WORKDIR /app
+
+# Install dependencies first (cache layer)
+COPY package.json ./
+RUN npm install
+
+# Copy source code
+COPY . .
+
+EXPOSE 3000
+
+# Dev mode with hot-reload
+CMD ["npx", "ts-node-dev", "--respawn", "--transpile-only", "src/app.ts"]

--- a/Backend/database/scripts/init_master.sql
+++ b/Backend/database/scripts/init_master.sql
@@ -5,6 +5,7 @@
 -- ============================================================
 
 CREATE EXTENSION IF NOT EXISTS "pgcrypto";  -- para gen_random_uuid()
+CREATE EXTENSION IF NOT EXISTS "vector";     -- pgvector — busca por similaridade
 
 -- 1. Usuários Globais
 --    Hóspedes que podem reservar em múltiplos hotéis

--- a/Backend/docker-compose.yml
+++ b/Backend/docker-compose.yml
@@ -1,0 +1,58 @@
+# ============================================================
+# ReservAqui — Docker Compose (Dev)
+# Uso: docker compose up --build
+# Reset banco: docker compose down -v && docker compose up --build
+# ============================================================
+
+services:
+  # ── PostgreSQL + pgvector ──────────────────────────────────
+  postgres:
+    image: pgvector/pgvector:pg16
+    container_name: reservaqui-db
+    restart: unless-stopped
+    environment:
+      POSTGRES_USER: ${DB_USER:-postgres}
+      POSTGRES_PASSWORD: ${DB_PASSWORD:?Defina DB_PASSWORD no .env}
+      POSTGRES_DB: ${DB_MASTER_NAME:-reservaqui_master}
+    ports:
+      - "${DB_PORT:-5432}:5432"
+    volumes:
+      # Volume persistente — dados sobrevivem ao restart
+      - pgdata:/var/lib/postgresql/data
+      # Scripts de inicialização — rodam apenas na PRIMEIRA vez (volume vazio)
+      - ./database/scripts/init_master.sql:/docker-entrypoint-initdb.d/01_init_master.sql:ro
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ${DB_USER:-postgres} -d ${DB_MASTER_NAME:-reservaqui_master}"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+
+  # ── Backend Node.js ────────────────────────────────────────
+  backend:
+    build: .
+    container_name: reservaqui-api
+    restart: unless-stopped
+    depends_on:
+      postgres:
+        condition: service_healthy
+    environment:
+      DB_HOST: postgres
+      DB_PORT: 5432
+      DB_USER: ${DB_USER:-postgres}
+      DB_PASSWORD: ${DB_PASSWORD}
+      DB_MASTER_NAME: ${DB_MASTER_NAME:-reservaqui_master}
+      JWT_SECRET: ${JWT_SECRET:?Defina JWT_SECRET no .env}
+      JWT_ACCESS_EXPIRES: ${JWT_ACCESS_EXPIRES:-1h}
+      JWT_REFRESH_EXPIRES: ${JWT_REFRESH_EXPIRES:-7d}
+      API_PREFIX: ${API_PREFIX:-/api}
+      PORT: ${PORT:-3000}
+      NODE_ENV: ${NODE_ENV:-development}
+    ports:
+      - "${PORT:-3000}:3000"
+    volumes:
+      # Monta o código local — edições refletem em tempo real (hot-reload)
+      - ./src:/app/src:ro
+      - ./database:/app/database:ro
+
+volumes:
+  pgdata:


### PR DESCRIPTION
## O que foi feito

Configuração Docker para o backend, permitindo subir banco + API com um único comando.

### Arquivos criados
- **`Dockerfile`** - Build do backend Node.js com hot-reload (ts-node-dev)
- **`docker-compose.yml`** - Orquestra PostgreSQL (pgvector) + API Express
- **`.dockerignore`** - Evita copiar node_modules/secrets para a imagem

### Alterações no banco
- `init_master.sql` - Adicionado `CREATE EXTENSION vector` (pgvector)
- Merge dos schemas mais recentes da develop (chat, tickets, favoritos, FCM)

### Como usar

```bash
cd Backend
cp .env.example .env    # preencher DB_PASSWORD e JWT_SECRET
docker compose up --build
```
A API sobe em http://localhost:3000/api/v1

Para resetar o banco (após alterar SQLs):
`docker compose down -v && docker compose up --build`
