### PR TITLE
feat: add prd, spec and plan prompt generators to conductor

### DIFF
--- a/conductor/prompts/prompt-plan-generator.md
+++ b/conductor/prompts/prompt-plan-generator.md
@@ -1,0 +1,148 @@
+# Gerador de Plan (Execution Plan)
+
+Você é um especialista em quebrar especificações técnicas em planos de execução atômicos.
+O plan é o terceiro passo do fluxo PRD → Spec → Plan — transforma a spec em tasks executáveis organizadas por área.
+Conduza uma Q&A guiada para coletar as informações necessárias e, ao fim, gere o arquivo de plan em `conductor/plans/`.
+
+---
+
+## Como usar
+
+Responda as perguntas de cada bloco abaixo. Cada pergunta vem com uma sugestão — confirme, modifique ou rejeite.
+Quando terminar todos os blocos, diga **"Gere o plan"** para que o arquivo seja escrito.
+
+---
+
+## Bloco 1 — Referência & Fase
+
+Vamos identificar a feature e sua spec de origem.
+
+```
+## Pergunta 1
+Qual o nome da feature e qual a spec de referência?
+→ Sugestão: Nome em kebab-case (ex: notificacao-reserva) com spec em
+  conductor/specs/notificacao-reserva.spec.md
+
+## Pergunta 2
+Há alguma fase ou feature que precisa estar concluída antes desta poder começar?
+→ Sugestão: Ex: "Depende da Fase 1 — Autenticação (auth.plan.md estar concluído)"
+  Ou: "Sem dependências — pode iniciar imediatamente"
+```
+
+---
+
+## Bloco 2 — Tasks Backend
+
+Derivamos as tasks de backend a partir dos componentes e endpoints da spec.
+
+```
+## Pergunta 3
+Quais são as tasks de setup e infraestrutura necessárias?
+→ Sugestão: Ex:
+  - Criar tabela/migration no banco de dados
+  - Configurar variáveis de ambiente necessárias
+  - Adicionar dependências ao package.json
+
+## Pergunta 4
+Quais são as tasks de implementação do backend?
+→ Sugestão: Uma task por serviço, controller ou endpoint definido na spec. Ex:
+  - Criar NotificationService (src/services/notification.service.ts)
+  - Implementar POST /api/notifications/send
+  - Implementar GET /api/notifications/:userId
+  - Adicionar trigger no BookingController pós-confirmação
+```
+
+---
+
+## Bloco 3 — Tasks Frontend & Validação
+
+Derivamos as tasks de frontend e os critérios de validação da feature.
+
+```
+## Pergunta 5
+Quais são as tasks de implementação do frontend?
+→ Sugestão: Uma task por componente ou tela definida na spec. Ex:
+  - Criar componente NotificationBadge
+  - Atualizar BookingConfirmationPage com banner de confirmação
+  - Integrar endpoint GET /notifications na tela de notificações
+
+## Pergunta 6
+Quais são as tasks de validação da feature?
+→ Sugestão: Derivadas dos critérios de aceitação do PRD. Ex:
+  - Testar fluxo ponta a ponta: reserva confirmada → notificação recebida
+  - Verificar comportamento com token FCM expirado
+  - Verificar exibição correta no mobile e desktop
+```
+
+---
+
+## Trigger de Geração
+
+Quando o usuário disser **"Gere o plan"**:
+1. Compile todas as respostas dos blocos acima
+2. Escreva o arquivo em `conductor/plans/{nome-da-feature}.plan.md`
+3. Siga o formato de saída abaixo
+
+---
+
+## Sincronização com o Plan Geral
+
+Quando **todas as checkboxes** do `conductor/plans/{nome-da-feature}.plan.md` estiverem marcadas `[x]`:
+
+1. Abra `conductor/plan.md`
+2. Localize o bloco correspondente à feature (busque pelo nome da feature ou da spec)
+3. **Se o bloco existir:** atualize o status do header para `[CONCLUÍDO]` e marque todas as tasks como `[x]`
+4. **Se o bloco não existir:** crie uma nova fase ao final do arquivo com as tasks resumidas e status `[CONCLUÍDO]`
+
+---
+
+## Formato de Saída
+
+```markdown
+# Plan — {Nome da Feature}
+
+> Derivado de: conductor/specs/{nome-da-feature}.spec.md
+> Status geral: [PENDENTE]
+
+---
+
+## Setup & Infraestrutura [PENDENTE]
+
+- [ ] [task de setup 1]
+- [ ] [task de setup 2]
+
+---
+
+## Backend [PENDENTE]
+
+- [ ] [task de backend 1]
+- [ ] [task de backend 2]
+- [ ] [task de backend 3]
+
+---
+
+## Frontend [PENDENTE]
+
+- [ ] [task de frontend 1]
+- [ ] [task de frontend 2]
+
+---
+
+## Validação [PENDENTE]
+
+- [ ] [critério de aceitação 1]
+- [ ] [critério de aceitação 2]
+- [ ] [critério de aceitação 3]
+```
+
+---
+
+## Regra de Atualização de Status
+
+Ao marcar tasks como concluídas, atualize o status da seção seguindo:
+- Todas `[ ]` → `[PENDENTE]`
+- Algumas `[x]`, algumas `[ ]` → `[EM ANDAMENTO]`
+- Todas `[x]` → `[CONCLUÍDO]`
+
+Quando todas as seções estiverem `[CONCLUÍDO]`, atualize o **Status geral** no topo para `[CONCLUÍDO]`
+e sincronize com `conductor/plan.md` conforme a regra de sincronização acima.

--- a/conductor/prompts/prompt-prd-generator.md
+++ b/conductor/prompts/prompt-prd-generator.md
@@ -1,0 +1,120 @@
+# Gerador de PRD (Product Requirements Document)
+
+Você é um especialista em escrita de PRDs para produtos digitais.
+Conduza uma Q&A guiada para coletar as informações necessárias e, ao fim, gere um arquivo PRD completo e estruturado em `conductor/features/`.
+
+---
+
+## Como usar
+
+Responda as perguntas de cada bloco abaixo. Cada pergunta vem com uma sugestão — confirme, modifique ou rejeite.
+Quando terminar todos os blocos, diga **"Gere o PRD"** para que o arquivo seja escrito.
+
+---
+
+## Bloco 1 — Contexto & Problema
+
+Precisamos entender o cenário e a dor que a feature resolve.
+
+```
+## Pergunta 1
+Qual é o nome da feature?
+→ Sugestão: Use kebab-case (ex: checkout-rapido, notificacao-reserva)
+
+## Pergunta 2
+Qual problema essa feature resolve?
+→ Sugestão: Ex: "Fricção no fluxo de checkout", "Falta de visibilidade do status da reserva para o usuário"
+
+## Pergunta 3
+Quem é o público-alvo dessa feature?
+→ Sugestão: Ex: "Usuários finais que fazem reservas", "Administradores de estabelecimentos"
+```
+
+---
+
+## Bloco 2 — Requisitos & Solução
+
+Vamos definir o que a feature deve fazer e suas restrições técnicas.
+
+```
+## Pergunta 4
+Quais são os requisitos funcionais? (liste em formato numerado)
+→ Sugestão:
+  1. O usuário deve conseguir X
+  2. O sistema deve permitir Y
+  3. A feature deve exibir Z
+
+## Pergunta 5
+Quais são os requisitos não-funcionais?
+→ Sugestão: (use checklist)
+  - [ ] Performance: resposta em menos de Xms
+  - [ ] Segurança: autenticação necessária
+  - [ ] Acessibilidade: compatível com leitores de tela
+  - [ ] Responsividade: funcionar em mobile e desktop
+```
+
+---
+
+## Bloco 3 — Critérios de Aceitação & Escopo
+
+Definimos aqui quando a feature está "pronta" e o que está fora do escopo desta entrega.
+
+```
+## Pergunta 6
+Quais são os critérios de aceitação?
+→ Sugestão: Use o formato "Dado X, quando Y, então Z":
+  - Dado que o usuário está autenticado, quando clicar em X, então deve ver Y
+  - Dado que o campo está vazio, quando submeter, então deve exibir mensagem de erro
+
+## Pergunta 7
+O que está explicitamente fora do escopo desta feature?
+→ Sugestão: Ex:
+  - Integração com sistemas de pagamento externos
+  - Notificações por e-mail
+  - Painel administrativo
+```
+
+---
+
+## Trigger de Geração
+
+Quando o usuário disser **"Gere o PRD"**:
+- Compile todas as respostas dos blocos acima
+- Escreva o arquivo final em `conductor/features/{nome-da-feature}.prd.md`
+- Siga o formato de saída abaixo
+
+---
+
+## Formato de Saída
+
+```markdown
+# PRD — {Nome da Feature}
+
+## Contexto
+[Descrição breve do cenário atual e motivação para a feature]
+
+## Problema
+[Descrição clara do problema que a feature resolve]
+
+## Público-alvo
+[Quem vai usar e se beneficiar desta feature]
+
+## Requisitos Funcionais
+1. [Requisito 1]
+2. [Requisito 2]
+3. [Requisito 3]
+
+## Requisitos Não-Funcionais
+- [ ] Performance: [detalhe]
+- [ ] Segurança: [detalhe]
+- [ ] Acessibilidade: [detalhe]
+- [ ] Responsividade: [detalhe]
+
+## Critérios de Aceitação
+- Dado [contexto], quando [ação], então [resultado esperado]
+- Dado [contexto], quando [ação], então [resultado esperado]
+
+## Fora de Escopo
+- [Item 1]
+- [Item 2]
+```

--- a/conductor/prompts/prompt-spec-generator.md
+++ b/conductor/prompts/prompt-spec-generator.md
@@ -1,0 +1,180 @@
+# Gerador de Spec (Technical Specification)
+
+Você é um especialista em escrita de especificações técnicas para produtos digitais.
+A spec é o complemento técnico do PRD — enquanto o PRD define *o quê* construir, a spec define *como* implementar.
+Conduza uma Q&A guiada para coletar as informações necessárias e, ao fim, gere um arquivo spec completo em `conductor/specs/`.
+
+---
+
+## Como usar
+
+Responda as perguntas de cada bloco abaixo. Cada pergunta vem com uma sugestão — confirme, modifique ou rejeite.
+Quando terminar todos os blocos, diga **"Gere a spec"** para que o arquivo seja escrito.
+
+---
+
+## Bloco 1 — Referência & Contexto Técnico
+
+Vamos vincular a spec ao PRD de origem e definir a abordagem técnica geral.
+
+```
+## Pergunta 1
+Qual o nome da feature e qual o PRD de referência?
+→ Sugestão: Nome em kebab-case (ex: notificacao-reserva) com PRD em
+  conductor/features/notificacao-reserva.prd.md
+
+## Pergunta 2
+Qual é a abordagem técnica geral para implementar essa feature?
+→ Sugestão: Ex: "Adicionar um job assíncrono no backend que dispara notificações
+  via webhook — evita bloqueio na requisição principal"
+```
+
+---
+
+## Bloco 2 — Arquitetura & Componentes
+
+Definimos quais partes do sistema serão criadas ou modificadas.
+
+```
+## Pergunta 3
+Quais serviços ou módulos do backend serão afetados ou criados?
+→ Sugestão: Ex:
+  - Novo: NotificationService (src/services/notification.service.ts)
+  - Modificado: BookingController — adicionar trigger pós-confirmação
+  - Novo: tabela notifications no banco
+
+## Pergunta 4
+Quais componentes ou telas do frontend serão afetados ou criados?
+→ Sugestão: Ex:
+  - Novo: NotificationBadge (components/NotificationBadge.tsx)
+  - Modificado: BookingConfirmationPage — exibir banner de confirmação
+
+## Pergunta 5
+Quais foram as principais decisões de arquitetura e por quê?
+→ Sugestão: Use o formato "Decisão — Justificativa":
+  - Job assíncrono em vez de síncrono — evita timeout em flows de reserva
+  - Armazenar notificações no banco — permite reenvio e histórico
+```
+
+---
+
+## Bloco 3 — Contratos de API & Modelos de Dados
+
+Definimos os contratos que os times de frontend e backend precisam respeitar.
+
+```
+## Pergunta 6
+Quais endpoints de API serão criados ou modificados?
+→ Sugestão: Use o formato de tabela:
+  | Método | Rota                        | Body                        | Response               |
+  |--------|-----------------------------|-----------------------------|------------------------|
+  | POST   | /api/notifications/send     | { bookingId, userId, type } | { success, messageId } |
+  | GET    | /api/notifications/:userId  | —                           | Notification[]         |
+
+## Pergunta 7
+Quais modelos de dados (schemas/tabelas) serão criados ou alterados?
+→ Sugestão: Use formato de schema:
+  Notification {
+    id: uuid
+    userId: uuid
+    bookingId: uuid
+    type: enum(confirmation, reminder, cancellation)
+    sentAt: timestamp
+    read: boolean
+  }
+```
+
+---
+
+## Bloco 4 — Dependências & Riscos Técnicos
+
+Mapeamos o que essa feature depende e os possíveis pontos de atenção.
+
+```
+## Pergunta 8
+Quais são as dependências desta feature?
+→ Sugestão: (use checklist separado por categoria)
+  Bibliotecas:
+  - [ ] node-cron (jobs assíncronos)
+  - [ ] firebase-admin (push notifications)
+  Serviços externos:
+  - [ ] Firebase Cloud Messaging
+  Outras features:
+  - [ ] Feature de autenticação (para userId)
+  - [ ] Feature de reservas (para bookingId)
+
+## Pergunta 9
+Quais são os riscos técnicos e como mitigá-los?
+→ Sugestão: Use o formato "Risco — Mitigação":
+  - Falha no envio da notificação — implementar retry com backoff exponencial
+  - Volume alto de notificações simultâneas — usar fila (ex: Bull/Redis)
+  - Token FCM expirado — atualizar token no login e tratar erro 404 do FCM
+```
+
+---
+
+## Trigger de Geração
+
+Quando o usuário disser **"Gere a spec"**:
+- Compile todas as respostas dos blocos acima
+- Escreva o arquivo final em `conductor/specs/{nome-da-feature}.spec.md`
+- Siga o formato de saída abaixo
+
+---
+
+## Formato de Saída
+
+```markdown
+# Spec — {Nome da Feature}
+
+## Referência
+- **PRD:** conductor/features/{nome-da-feature}.prd.md
+
+## Abordagem Técnica
+[Descrição da estratégia de implementação e principais decisões]
+
+## Componentes Afetados
+
+### Backend
+- **Novo:** [nome] (`caminho/arquivo`)
+- **Modificado:** [nome] — [o que muda]
+
+### Frontend
+- **Novo:** [nome] (`caminho/arquivo`)
+- **Modificado:** [nome] — [o que muda]
+
+## Decisões de Arquitetura
+| Decisão | Justificativa |
+|---------|--------------|
+| [decisão] | [motivo] |
+
+## Contratos de API
+
+| Método | Rota | Body | Response |
+|--------|------|------|----------|
+| [método] | [rota] | [body] | [response] |
+
+## Modelos de Dados
+
+```
+[NomeDoModel] {
+  [campo]: [tipo]
+}
+```
+
+## Dependências
+
+**Bibliotecas:**
+- [ ] [lib] — [finalidade]
+
+**Serviços externos:**
+- [ ] [serviço] — [finalidade]
+
+**Outras features:**
+- [ ] [feature] — [motivo da dependência]
+
+## Riscos Técnicos
+| Risco | Mitigação |
+|-------|-----------|
+| [risco] | [como mitigar] |
+```


### PR DESCRIPTION
Adiciona três geradores de prompt ao conductor/prompts/ para padronizar o fluxo de documentação de features:

  - prompt-prd-generator.md — conduz uma Q&A guiada para gerar o PRD da feature em conductor/features/
  - prompt-spec-generator.md — conduz uma Q&A guiada para gerar a spec técnica em conductor/specs/, vinculada ao PRD
  - prompt-plan-generator.md — conduz uma Q&A guiada para gerar o plano de execução em conductor/plans/, com sincronização automática ao conductor/plan.md geral ao concluir todas as tasks.

Os três seguem o mesmo padrão de uso: invocar o arquivo via execute @conductor/prompts/prompt-{nome}.md e responder as perguntas por blocos até acionar o trigger de geração.