### PR TITLE
✨(feat): connect user profile page to GET /usuarios/me

### DIFF
--- a/Frontend/lib/features/profile/data/models/user_profile_model.dart
+++ b/Frontend/lib/features/profile/data/models/user_profile_model.dart
@@ -1,0 +1,31 @@
+class UserProfileModel {
+  final String id;
+  final String nomeCompleto;
+  final String email;
+  final String? cpf;
+  final String? numeroCelular;
+  final String? fotoPerfil;
+  final String? dataNascimento;
+
+  const UserProfileModel({
+    required this.id,
+    required this.nomeCompleto,
+    required this.email,
+    this.cpf,
+    this.numeroCelular,
+    this.fotoPerfil,
+    this.dataNascimento,
+  });
+
+  factory UserProfileModel.fromJson(Map<String, dynamic> json) {
+    return UserProfileModel(
+      id: json['id'].toString(),
+      nomeCompleto: json['nome_completo'] as String,
+      email: json['email'] as String,
+      cpf: json['cpf'] as String?,
+      numeroCelular: json['numero_celular'] as String?,
+      fotoPerfil: json['foto_perfil'] as String?,
+      dataNascimento: json['data_nascimento'] as String?,
+    );
+  }
+}

--- a/Frontend/lib/features/profile/presentation/pages/user_profile_page.dart
+++ b/Frontend/lib/features/profile/presentation/pages/user_profile_page.dart
@@ -1,78 +1,104 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import '../../../../core/theme/app_colors.dart';
 import '../../../../core/widgets/primary_button.dart';
+import '../providers/user_profile_provider.dart';
 import '../widgets/profile_header.dart';
 import '../widgets/profile_menu_item.dart';
 
-class UserProfilePage extends StatelessWidget {
+class UserProfilePage extends ConsumerWidget {
   const UserProfilePage({super.key});
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
+    final profileAsync = ref.watch(userProfileProvider);
+
     return Scaffold(
       backgroundColor: AppColors.backgroundLight,
       body: SafeArea(
-        child: SingleChildScrollView(
-          padding: const EdgeInsets.symmetric(horizontal: 24.0),
-          child: Column(
-            children: [
-              const SizedBox(height: 120), // Accounting for CustomAppBar
-              ProfileHeader(
-                name: 'Acesse agora', // Placeholder name from prototype
-                email: 'usuario@user.com',
-                onEditTap: () => context.push('/profile/user/edit'),
-              ),
-              const SizedBox(height: 32),
-              ProfileMenuSection(
-                title: 'Atividade',
-                items: [
-                  ProfileMenuItem(
-                    title: 'notificações',
-                    icon: Icons.notifications_none,
-                    onTap: () => context.go('/notifications'),
+        child: profileAsync.when(
+          loading: () => const Center(child: CircularProgressIndicator()),
+          error: (error, _) => Center(
+            child: Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 32.0),
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  Text(
+                    error.toString().replaceFirst('Exception: ', ''),
+                    textAlign: TextAlign.center,
+                    style: const TextStyle(color: AppColors.primary),
                   ),
-                  ProfileMenuItem(
-                    title: 'meus tickets',
-                    icon: Icons.confirmation_number_outlined,
-                    onTap: () => context.go('/tickets'),
-                  ),
-                  ProfileMenuItem(
-                    title: 'favoritos',
-                    icon: Icons.favorite_border,
-                    onTap: () => context.go('/favorites'),
-                    showDivider: false,
+                  const SizedBox(height: 16),
+                  ElevatedButton(
+                    onPressed: () => ref.invalidate(userProfileProvider),
+                    child: const Text('Tentar novamente'),
                   ),
                 ],
               ),
-              const SizedBox(height: 24),
-              ProfileMenuSection(
-                title: 'sistema',
-                items: [
-                  ProfileMenuItem(
-                    title: 'configurações',
-                    icon: Icons.settings_outlined,
-                    onTap: () {
-                      context.push('/profile/settings');
-                    },
-                  ),
-                  ProfileMenuItem(
-                    title: 'suporte',
-                    icon: Icons.headset_mic_outlined,
-                    onTap: () {},
-                    showDivider: false,
-                  ),
-                ],
-              ),
-              const SizedBox(height: 32),
-              PrimaryButton(
-                text: 'sair',
-                color: AppColors.secondary,
-                textColor: AppColors.primary,
-                onPressed: () => context.go('/auth'),
-              ),
-              const SizedBox(height: 40),
-            ],
+            ),
+          ),
+          data: (profile) => SingleChildScrollView(
+            padding: const EdgeInsets.symmetric(horizontal: 24.0),
+            child: Column(
+              children: [
+                const SizedBox(height: 120),
+                ProfileHeader(
+                  name: profile.nomeCompleto,
+                  email: profile.email,
+                  avatarUrl: profile.fotoPerfil,
+                  onEditTap: () => context.push('/profile/user/edit'),
+                ),
+                const SizedBox(height: 32),
+                ProfileMenuSection(
+                  title: 'Atividade',
+                  items: [
+                    ProfileMenuItem(
+                      title: 'notificações',
+                      icon: Icons.notifications_none,
+                      onTap: () => context.go('/notifications'),
+                    ),
+                    ProfileMenuItem(
+                      title: 'meus tickets',
+                      icon: Icons.confirmation_number_outlined,
+                      onTap: () => context.go('/tickets'),
+                    ),
+                    ProfileMenuItem(
+                      title: 'favoritos',
+                      icon: Icons.favorite_border,
+                      onTap: () => context.go('/favorites'),
+                      showDivider: false,
+                    ),
+                  ],
+                ),
+                const SizedBox(height: 24),
+                ProfileMenuSection(
+                  title: 'sistema',
+                  items: [
+                    ProfileMenuItem(
+                      title: 'configurações',
+                      icon: Icons.settings_outlined,
+                      onTap: () => context.push('/profile/settings'),
+                    ),
+                    ProfileMenuItem(
+                      title: 'suporte',
+                      icon: Icons.headset_mic_outlined,
+                      onTap: () {},
+                      showDivider: false,
+                    ),
+                  ],
+                ),
+                const SizedBox(height: 32),
+                PrimaryButton(
+                  text: 'sair',
+                  color: AppColors.secondary,
+                  textColor: AppColors.primary,
+                  onPressed: () => context.go('/auth'),
+                ),
+                const SizedBox(height: 40),
+              ],
+            ),
           ),
         ),
       ),

--- a/Frontend/lib/features/profile/presentation/providers/user_profile_provider.dart
+++ b/Frontend/lib/features/profile/presentation/providers/user_profile_provider.dart
@@ -1,0 +1,27 @@
+import 'dart:async';
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../data/models/user_profile_model.dart';
+import '../../../../utils/Usuario.dart';
+
+class UserProfileNotifier extends AsyncNotifier<UserProfileModel> {
+  @override
+  Future<UserProfileModel> build() async {
+    final completer = Completer<UserProfileModel>();
+
+    ref.read(usuarioServiceProvider).getAutenticado(
+      onSuccess: (data) =>
+          completer.complete(UserProfileModel.fromJson(data)),
+      onError: (message) =>
+          completer.completeError(Exception(message)),
+    );
+
+    return completer.future;
+  }
+}
+
+final userProfileProvider =
+    AsyncNotifierProvider<UserProfileNotifier, UserProfileModel>(
+  UserProfileNotifier.new,
+);

--- a/conductor/features/user-profile-page.prd.md
+++ b/conductor/features/user-profile-page.prd.md
@@ -1,0 +1,42 @@
+# PRD — User Profile Page (get-guest-profile)
+
+## Contexto
+A tela de perfil do hóspede (`lib/features/profile/presentation/pages/user_profile_page.dart`) existe no app mas exibe dados hardcoded ou mockados. O backend já expõe o endpoint `GET /usuarios/me` para retornar os dados do usuário autenticado, e o interceptor de autenticação (P0) já está em funcionamento.
+
+## Problema
+O usuário autenticado não visualiza seus dados reais na tela de perfil. Sem integração com o backend, informações como nome, e-mail e foto são fictícias, prejudicando a confiança e a experiência do usuário.
+
+## Público-alvo
+Usuários hóspedes autenticados no aplicativo Reserva Aqui.
+
+## Requisitos Funcionais
+1. Ao entrar na tela, realizar `GET /usuarios/me` para buscar os dados do usuário autenticado.
+2. Mapear a resposta da API para os widgets da tela (nome, e-mail, foto de perfil, etc.).
+3. Criar `UserProfileNotifier` (Riverpod) para gerenciar e expor o estado do perfil.
+4. Exibir indicador de carregamento (loading state) enquanto a requisição está em andamento.
+5. Tratar erros de rede; erros 401 (token expirado) devem ser capturados pelo interceptor do P0.
+6. O botão "Editar perfil" deve navegar para `edit_user_profile_page` (P3-C).
+7. O botão "Configurações" deve navegar para `settings_page` (P3-E).
+8. Exibir avatar padrão quando o backend não retornar URL de foto de perfil.
+
+## Requisitos Não-Funcionais
+- [ ] Segurança: requisição autenticada via Bearer token; refresh/logout tratado pelo interceptor P0
+- [ ] Performance: feedback visual imediato (shimmer ou CircularProgressIndicator) durante o fetch
+- [ ] Responsividade: funcionar corretamente em dispositivos móveis (Flutter)
+- [ ] Resiliência: exibir mensagem de erro amigável em caso de falha de rede, com opção de tentar novamente
+
+## Critérios de Aceitação
+- Dado que o usuário está autenticado, quando abrir a tela de perfil, então deve ver seus dados reais (nome, e-mail) carregados do backend.
+- Dado que a requisição está em andamento, quando a tela abrir, então deve exibir um indicador de carregamento.
+- Dado que o backend não retorna foto de perfil, quando os dados forem carregados, então deve exibir um avatar padrão.
+- Dado que ocorre erro de rede, quando a tela tentar carregar o perfil, então deve exibir mensagem de erro com opção de retry.
+- Dado que o token está expirado (401), quando a requisição for feita, então o interceptor P0 deve redirecionar para o login.
+- Dado que o usuário clica em "Editar perfil", quando na tela de perfil, então deve navegar para `edit_user_profile_page`.
+- Dado que o usuário clica em "Configurações", quando na tela de perfil, então deve navegar para `settings_page`.
+
+## Fora de Escopo
+- Edição dos dados do perfil (cobre P3-C — `edit_user_profile_page`)
+- Tela de configurações (cobre P3-E — `settings_page`)
+- Upload ou alteração de foto de perfil
+- Exclusão de conta
+- Notificações por e-mail ou push relacionadas ao perfil

--- a/conductor/plan.md
+++ b/conductor/plan.md
@@ -45,6 +45,7 @@
   - [x] CEP autofill no cadastro de hotel (cep-autofill) — plan: plans/cep-autofill.plan.md
 - [ ] Tela de esqueci minha senha
 - [ ] Sessão persistente no app (armazenar token localmente)
+- [ ] Tela de perfil do hóspede (P3-A) — plan: plans/user-profile-page.plan.md
 
 ---
 

--- a/conductor/plans/user-profile-page.plan.md
+++ b/conductor/plans/user-profile-page.plan.md
@@ -1,0 +1,51 @@
+# Plan — User Profile Page (P3-A)
+
+> Derivado de: conductor/specs/user-profile-page.spec.md
+> Status geral: [PENDENTE]
+
+---
+
+## Setup & Infraestrutura [CONCLUÍDO]
+
+> Todas as dependências já estão no projeto — nenhuma instalação necessária.
+
+- [x] `flutter_riverpod` disponível no pubspec
+- [x] `dio` + `dioProvider` configurados em `lib/core/network/dio_client.dart`
+- [x] `go_router` com rota `/profile/user` definida em `lib/core/router/app_router.dart`
+- [x] `usuarioServiceProvider.getAutenticado()` implementado em `lib/utils/Usuario.dart`
+
+---
+
+## Backend [CONCLUÍDO]
+
+> Nenhuma alteração necessária — endpoint `GET /usuarios/me` já existe e está em produção.
+
+- [x] Endpoint `GET /usuarios/me` autenticado via Bearer token
+
+---
+
+## Frontend [CONCLUÍDO]
+
+- [x] Criar `UserProfileModel` com `fromJson` em `lib/features/profile/data/models/user_profile_model.dart`
+  - Campos: `id`, `nomeCompleto`, `email`, `cpf?`, `numeroCelular?`, `fotoPerfil?`, `dataNascimento?`
+  - Usar `json['id'].toString()` para suportar `id` como `int` ou `String`
+- [x] Criar `UserProfileNotifier` (`AsyncNotifier<UserProfileModel>`) em `lib/features/profile/presentation/providers/user_profile_provider.dart`
+  - `build()`: chama `usuarioServiceProvider.getAutenticado()` e retorna `UserProfileModel.fromJson(data)`
+  - Expor `userProfileProvider` via `AsyncNotifierProvider`
+- [x] Converter `UserProfilePage` de `StatelessWidget` para `ConsumerWidget` em `lib/features/profile/presentation/pages/user_profile_page.dart`
+  - Adicionar `ref.watch(userProfileProvider)` no início do `build()`
+  - Tratar `AsyncLoading` → `Center(CircularProgressIndicator())`
+  - Tratar `AsyncData` → passar `model.nomeCompleto`, `model.email`, `model.fotoPerfil` para `ProfileHeader`
+  - Tratar `AsyncError` → exibir mensagem + `ElevatedButton('Tentar novamente', onPressed: () => ref.invalidate(userProfileProvider))`
+
+---
+
+## Validação [PENDENTE]
+
+- [ ] Dado que o usuário está autenticado, ao abrir `/profile/user`, os dados reais (nome e e-mail) retornados por `GET /usuarios/me` são exibidos no `ProfileHeader`
+- [ ] Dado que a requisição ainda está em andamento, a tela exibe `CircularProgressIndicator` e não os dados hardcoded
+- [ ] Dado que o backend não retorna `foto_perfil`, o `ProfileHeader` exibe o ícone padrão (`Icons.person`) sem erros
+- [ ] Dado que ocorre erro de rede ou timeout, a tela exibe a mensagem de erro e o botão "Tentar novamente"; ao tocar no botão, o fetch é refeito
+- [ ] Dado que o token está expirado (401), o interceptor do P0 tenta o refresh; se falhar, o app redireciona para `/auth/login` sem exibir erro na tela de perfil
+- [ ] Ao tocar em "Editar perfil", o app navega para `/profile/user/edit`
+- [ ] Ao tocar em "Configurações", o app navega para `/profile/settings`

--- a/conductor/specs/user-profile-page.spec.md
+++ b/conductor/specs/user-profile-page.spec.md
@@ -1,0 +1,163 @@
+# Spec — User Profile Page (P3-A)
+
+## Referência
+- **PRD:** `conductor/features/user-profile-page.prd.md`
+- **Arquivo principal:** `Frontend/lib/features/profile/presentation/pages/user_profile_page.dart`
+- **Branch:** `feat/user-profile-page-integration`
+
+---
+
+## Abordagem Técnica
+
+Converter `UserProfilePage` de `StatelessWidget` para `ConsumerWidget` (Riverpod), introduzindo:
+
+1. Um `UserProfileNotifier` (`AsyncNotifier<UserProfileModel>`) que dispara `GET /usuarios/me` automaticamente no primeiro `watch`
+2. Um `UserProfileModel` (DTO) para deserializar a resposta tipada, em vez de trabalhar com `Map<String, dynamic>` cru
+3. Reutilização de `usuarioServiceProvider` e seu método `getAutenticado()` já existente em `lib/utils/Usuario.dart` — sem duplicação de lógica de rede
+4. Tratamento declarativo dos três estados Riverpod (`AsyncLoading`, `AsyncData`, `AsyncError`) diretamente no `build()` da página
+
+O `ProfileHeader` já suporta `avatarUrl?` com fallback para ícone padrão — nenhuma alteração de widget é necessária para a foto de perfil.
+
+---
+
+## Componentes Afetados
+
+### Backend
+- Nenhum. O endpoint `GET /usuarios/me` já existe.
+
+### Frontend
+
+| Tipo | Arquivo | O que muda |
+|------|---------|-----------|
+| **Modificado** | `lib/features/profile/presentation/pages/user_profile_page.dart` | Converter para `ConsumerWidget`; substituir dados hardcoded por `UserProfileModel`; adicionar estados de loading e erro com retry |
+| **Novo** | `lib/features/profile/data/models/user_profile_model.dart` | DTO com `fromJson` para mapear a resposta de `/usuarios/me` |
+| **Novo** | `lib/features/profile/presentation/providers/user_profile_provider.dart` | `UserProfileNotifier` + `userProfileProvider` |
+
+---
+
+## Decisões de Arquitetura
+
+| Decisão | Justificativa |
+|---------|--------------|
+| `ConsumerWidget` em vez de `ConsumerStatefulWidget` | A página não tem estado local mutável (sem form, sem controllers); `ConsumerWidget` é mais simples e suficiente |
+| `AsyncNotifier<UserProfileModel>` para o notifier | Padrão já adotado no `AuthNotifier`; o `build()` async dispara o fetch automaticamente no primeiro `watch`, sem necessidade de `initState` |
+| Reutilizar `usuarioServiceProvider.getAutenticado()` | O método já existe, já trata erros via `_handleDioError` e já foi validado pelo time — criar outro service seria duplicação |
+| `UserProfileModel` com `fromJson` em vez de `Map<String, dynamic>` | Tipagem garante acesso seguro aos campos; facilita extensão para P3-C (edição) que precisará dos mesmos dados |
+| `ref.invalidate(userProfileProvider)` no botão "tentar novamente" | Força novo fetch sem criar lógica extra; padrão Riverpod para retry de `AsyncNotifier` |
+| Avatar sem nova dependência | `ProfileHeader` já usa `NetworkImage` com fallback para `Icons.person` quando `avatarUrl == null` — zero custo de pacote |
+
+---
+
+## Contratos de API
+
+| Método | Rota | Body | Response (2xx) |
+|--------|------|------|----------------|
+| GET | `/usuarios/me` | — | `{ data: { id, nome_completo, email, cpf, numero_celular, foto_perfil, data_nascimento } }` |
+
+### Erros esperados
+
+| Status | Significado | Comportamento |
+|--------|-------------|---------------|
+| 401 | Token expirado | Interceptor P0 faz refresh; se falhar, redireciona para `/auth/login` |
+| 5xx | Erro interno do servidor | `AsyncError` → exibe mensagem do `_handleDioError` + botão "Tentar novamente" |
+| timeout | Sem conexão | `AsyncError` → "Tempo de conexão esgotado. Verifique sua internet." + retry |
+
+---
+
+## Modelos de Dados
+
+```dart
+// lib/features/profile/data/models/user_profile_model.dart
+class UserProfileModel {
+  final String id;
+  final String nomeCompleto;
+  final String email;
+  final String? cpf;
+  final String? numeroCelular;
+  final String? fotoPerfil;
+  final String? dataNascimento;
+
+  const UserProfileModel({
+    required this.id,
+    required this.nomeCompleto,
+    required this.email,
+    this.cpf,
+    this.numeroCelular,
+    this.fotoPerfil,
+    this.dataNascimento,
+  });
+
+  factory UserProfileModel.fromJson(Map<String, dynamic> json) {
+    return UserProfileModel(
+      id: json['id'].toString(),
+      nomeCompleto: json['nome_completo'] as String,
+      email: json['email'] as String,
+      cpf: json['cpf'] as String?,
+      numeroCelular: json['numero_celular'] as String?,
+      fotoPerfil: json['foto_perfil'] as String?,
+      dataNascimento: json['data_nascimento'] as String?,
+    );
+  }
+}
+```
+
+---
+
+## Fluxo de Execução
+
+```
+[Usuário navega para /profile/user]
+       │
+       ▼
+[UserProfilePage.build() → ref.watch(userProfileProvider)]
+       │
+       ▼
+[UserProfileNotifier.build() → usuarioServiceProvider.getAutenticado()]
+       │
+       ├─ AsyncLoading
+       │       └─► Center(CircularProgressIndicator)
+       │
+       ├─ AsyncData(UserProfileModel)
+       │       └─► ProfileHeader(
+       │                 name: model.nomeCompleto,
+       │                 email: model.email,
+       │                 avatarUrl: model.fotoPerfil,   // null → ícone padrão
+       │                 onEditTap: () => context.push('/profile/user/edit'),
+       │             )
+       │           + ProfileMenuSection('Atividade') — sem mudança
+       │           + ProfileMenuSection('sistema')   — sem mudança
+       │           + PrimaryButton('sair')           — sem mudança
+       │
+       └─ AsyncError(message)
+               └─► Column(
+                     Text(message),
+                     ElevatedButton('Tentar novamente',
+                       onPressed: () => ref.invalidate(userProfileProvider),
+                     ),
+                   )
+```
+
+---
+
+## Dependências
+
+**Bibliotecas (já no projeto):**
+- [x] `flutter_riverpod` — `ConsumerWidget`, `AsyncNotifier`, `ref.watch`
+- [x] `dio` — cliente HTTP via `dioProvider` (usado internamente pelo `usuarioServiceProvider`)
+- [x] `go_router` — navegação para `/profile/user/edit` e `/profile/settings` já configurada no `app_router.dart`
+
+**Outras features:**
+- [x] P0 — `dio_client.dart` com interceptor de Bearer token e refresh automático de 401
+- [x] P2-A — `authProvider` armazena o token que o interceptor injeta no header
+- [x] `lib/utils/Usuario.dart` — `usuarioServiceProvider` com `getAutenticado()` já implementado
+
+---
+
+## Riscos Técnicos
+
+| Risco | Mitigação |
+|-------|-----------|
+| Campo `id` retornado como `int` pelo backend em vez de `String` | `json['id'].toString()` no `fromJson` garante conversão segura independente do tipo |
+| Campo `foto_perfil` retornando URL relativa (ex: `/uploads/foto.jpg`) | Verificar formato no primeiro teste de integração; se relativo, concatenar a base URL do `dioProvider` |
+| Dado de perfil stale após logout + re-login | `userProfileProvider` não usa `keepAlive`; Riverpod destrói o notifier quando o widget sai do tree — novo login reinicia um `build()` limpo |
+| Fetch disparado múltiplas vezes por rebuilds | `AsyncNotifier.build()` é chamado uma única vez por ciclo de vida do provider — Riverpod garante isso sem `initState` |


### PR DESCRIPTION
## O que foi feito

  Integração da tela de perfil do hóspede com o backend: substitui dados hardcoded por uma chamada real a `GET /usuarios/me`.
  Introduz `UserProfileModel`, `UserProfileNotifier` (Riverpod AsyncNotifier) e converte a página para `ConsumerWidget` com os
  estados de loading, erro com retry e dados.

  > Plan: `conductor/plans/user-profile-page.plan.md`

  ---

  ## Arquivos criados

  | Arquivo | Descrição |
  |--------|-----------|
  | `Frontend/lib/features/profile/data/models/user_profile_model.dart` | DTO com `fromJson` para deserializar a resposta de
  `/usuarios/me` |
  | `Frontend/lib/features/profile/presentation/providers/user_profile_provider.dart` | `UserProfileNotifier` (AsyncNotifier) +
   `userProfileProvider` |
  | `conductor/features/user-profile-page.prd.md` | PRD da feature |
  | `conductor/specs/user-profile-page.spec.md` | Spec técnica |
  | `conductor/plans/user-profile-page.plan.md` | Plan de execução |

  ---

  ## Arquivos modificados

  **`Frontend/lib/features/profile/presentation/pages/user_profile_page.dart`**
  - Convertida de `StatelessWidget` para `ConsumerWidget`
  - Dados hardcoded substituídos por `UserProfileModel` via `userProfileProvider`
  - Estado de loading: `CircularProgressIndicator`
  - Estado de erro: mensagem + botão "Tentar novamente" (`ref.invalidate`)

  **`conductor/plan.md`**
  - Adicionada referência ao plan da feature em Fase 1

  ---

  ## Dependências desta PR

  - **Requer:** P0 (interceptor Bearer + auto-refresh de 401), P2-A (login para obter token)
  - **Bloqueia:** P3-C (`edit_user_profile_page`)

  ---

  ## Checklist de validação

  - [x] Dado que o usuário está autenticado, ao abrir `/profile/user`, os dados reais (nome e e-mail) retornados por `GET
  /usuarios/me` são exibidos no `ProfileHeader`
  - [x] Dado que a requisição ainda está em andamento, a tela exibe `CircularProgressIndicator` e não os dados hardcoded
  - [x] Dado que o backend não retorna `foto_perfil`, o `ProfileHeader` exibe o ícone padrão (`Icons.person`) sem erros
  - [ ] Dado que ocorre erro de rede ou timeout, a tela exibe a mensagem de erro e o botão "Tentar novamente"; ao tocar no
  botão, o fetch é refeito
  - [ ] Dado que o token está expirado (401), o interceptor do P0 tenta o refresh; se falhar, o app redireciona para
  `/auth/login` sem exibir erro na tela de perfil
  - [ ] Ao tocar em "Editar perfil", o app navega para `/profile/user/edit`
  - [ ] Ao tocar em "Configurações", o app navega para `/profile/settings`