### PR TITLE
RES-12 ✨(feat):edit user profile page

### DIFF
--- a/Frontend/lib/features/profile/data/models/user_profile_model.dart
+++ b/Frontend/lib/features/profile/data/models/user_profile_model.dart
@@ -1,0 +1,31 @@
+class UserProfileModel {
+  final String id;
+  final String nomeCompleto;
+  final String email;
+  final String? cpf;
+  final String? numeroCelular;
+  final String? fotoPerfil;
+  final String? dataNascimento;
+
+  const UserProfileModel({
+    required this.id,
+    required this.nomeCompleto,
+    required this.email,
+    this.cpf,
+    this.numeroCelular,
+    this.fotoPerfil,
+    this.dataNascimento,
+  });
+
+  factory UserProfileModel.fromJson(Map<String, dynamic> json) {
+    return UserProfileModel(
+      id: json['id'].toString(),
+      nomeCompleto: json['nome_completo'] as String,
+      email: json['email'] as String,
+      cpf: json['cpf'] as String?,
+      numeroCelular: json['numero_celular'] as String?,
+      fotoPerfil: json['foto_perfil'] as String?,
+      dataNascimento: json['data_nascimento'] as String?,
+    );
+  }
+}

--- a/Frontend/lib/features/profile/presentation/pages/edit_user_profile_page.dart
+++ b/Frontend/lib/features/profile/presentation/pages/edit_user_profile_page.dart
@@ -1,17 +1,23 @@
+import 'dart:async';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
+import 'package:mask_text_input_formatter/mask_text_input_formatter.dart';
 import '../../../../core/theme/app_colors.dart';
 import '../../../../core/widgets/primary_button.dart';
+import '../providers/user_profile_provider.dart';
 import '../widgets/profile_form_section.dart';
+import '../../../../utils/Usuario.dart';
 
-class EditUserProfilePage extends StatefulWidget {
+class EditUserProfilePage extends ConsumerStatefulWidget {
   const EditUserProfilePage({super.key});
 
   @override
-  State<EditUserProfilePage> createState() => _EditUserProfilePageState();
+  ConsumerState<EditUserProfilePage> createState() => _EditUserProfilePageState();
 }
 
-class _EditUserProfilePageState extends State<EditUserProfilePage> {
+class _EditUserProfilePageState extends ConsumerState<EditUserProfilePage> {
   final _formKey = GlobalKey<FormState>();
   late TextEditingController _nameController;
   late TextEditingController _emailController;
@@ -25,13 +31,44 @@ class _EditUserProfilePageState extends State<EditUserProfilePage> {
   bool _obscurePassword = true;
   bool _obscureConfirmPassword = true;
 
+
+  final _dateMask = MaskTextInputFormatter(
+    mask: '##/##/####',
+    filter: {"#": RegExp(r'[0-9]')},
+  );
+
+  bool _isLoadingPassword = false;
+
   @override
   void initState() {
     super.initState();
-    _nameController = TextEditingController(text: 'Acesse agora');
-    _emailController = TextEditingController(text: 'usuario@user.com');
-    _phoneController = TextEditingController();
-    _birthdateController = TextEditingController();
+    final profile = ref.read(userProfileProvider).value;
+
+    // Converter data de YYYY-MM-DDTHH:mm:ss para DD/MM/AAAA
+    String birthDateStr = profile?.dataNascimento ?? '';
+    if (birthDateStr.isNotEmpty) {
+      try {
+        if (birthDateStr.contains('T')) {
+          birthDateStr = birthDateStr.split('T')[0];
+        }
+        final parts = birthDateStr.split('-');
+        if (parts.length == 3) {
+          birthDateStr = '${parts[2]}/${parts[1]}/${parts[0]}';
+        }
+      } catch (_) {}
+    }
+
+    String phone = profile?.numeroCelular ?? '';
+    if (phone.length == 11) {
+      phone = '(${phone.substring(0, 2)}) ${phone.substring(2, 7)}-${phone.substring(7)}';
+    } else if (phone.length == 10) {
+      phone = '(${phone.substring(0, 2)}) ${phone.substring(2, 6)}-${phone.substring(6)}';
+    }
+
+    _nameController = TextEditingController(text: profile?.nomeCompleto ?? '');
+    _emailController = TextEditingController(text: profile?.email ?? '');
+    _phoneController = TextEditingController(text: phone);
+    _birthdateController = TextEditingController(text: birthDateStr);
     _currentPasswordController = TextEditingController();
     _passwordController = TextEditingController();
     _confirmPasswordController = TextEditingController();
@@ -49,19 +86,79 @@ class _EditUserProfilePageState extends State<EditUserProfilePage> {
     super.dispose();
   }
 
-  Future<void> _savProfile() async {
-    if (_formKey.currentState!.validate()) {
-      setState(() => _isLoading = true);
-      try {
-        await Future.delayed(const Duration(seconds: 1));
-        if (!mounted) return;
-        ScaffoldMessenger.of(context).showSnackBar(
-          const SnackBar(content: Text('Perfil atualizado com sucesso')),
-        );
-        context.pop();
-      } finally {
-        if (mounted) setState(() => _isLoading = false);
-      }
+  Future<void> _handleSave() async {
+    if (!_formKey.currentState!.validate()) return;
+
+    // Salvar dados pessoais
+    final successPersonal = await _savePersonalData();
+    if (!successPersonal) return;
+
+    // Se a senha estiver preenchida, tenta salvar a senha
+    if (_passwordController.text.isNotEmpty) {
+      await _savePassword();
+      // O pop() já acontece dentro do _savePassword em caso de sucesso
+    } else {
+      // Se não tem senha pra mudar, e o personal deu certo, volta agora
+      if (mounted) context.pop();
+    }
+  }
+
+  Future<bool> _savePersonalData() async {
+    setState(() => _isLoading = true);
+    final completer = Completer<bool>();
+
+    try {
+      await ref.read(usuarioServiceProvider).update(
+            nomeCompleto: _nameController.text,
+            email: _emailController.text,
+            numeroCelular: _phoneController.text,
+            dataNascimento: _birthdateController.text,
+            onSuccess: (u) {
+              ref.invalidate(userProfileProvider);
+              ScaffoldMessenger.of(context).showSnackBar(
+                const SnackBar(content: Text('Perfil atualizado com sucesso ✓')),
+              );
+              completer.complete(true);
+            },
+            onError: (message) {
+              ScaffoldMessenger.of(context).showSnackBar(
+                SnackBar(content: Text(message)),
+              );
+              completer.complete(false);
+            },
+          );
+      return await completer.future;
+    } finally {
+      if (mounted) setState(() => _isLoading = false);
+    }
+  }
+
+  Future<void> _savePassword() async {
+    setState(() => _isLoadingPassword = true);
+    final completer = Completer<void>();
+
+    try {
+      await ref.read(usuarioServiceProvider).changePassword(
+            senhaAtual: _currentPasswordController.text,
+            novaSenha: _passwordController.text,
+            confirmarNovaSenha: _confirmPasswordController.text,
+            onSuccess: () {
+              ScaffoldMessenger.of(context).showSnackBar(
+                const SnackBar(content: Text('Senha alterada com sucesso ✓')),
+              );
+              if (mounted) context.pop();
+              completer.complete();
+            },
+            onError: (message) {
+              ScaffoldMessenger.of(context).showSnackBar(
+                SnackBar(content: Text(message)),
+              );
+              completer.complete();
+            },
+          );
+      await completer.future;
+    } finally {
+      if (mounted) setState(() => _isLoadingPassword = false);
     }
   }
 
@@ -118,14 +215,22 @@ class _EditUserProfilePageState extends State<EditUserProfilePage> {
                       },
                     ),
                     const SizedBox(height: 16),
-                    _buildTextField(
+                     _buildTextField(
                       controller: _phoneController,
                       label: 'Número de Celular',
                       icon: Icons.phone_outlined,
                       keyboardType: TextInputType.phone,
+                      inputFormatters: [
+                        FilteringTextInputFormatter.digitsOnly,
+                        _BrazilianPhoneFormatter(),
+                      ],
                       validator: (value) {
                         if (value?.isEmpty ?? true) {
                           return 'Celular é obrigatório';
+                        }
+                        final clean = value!.replaceAll(RegExp(r'\D'), '');
+                        if (clean.length != 10 && clean.length != 11) {
+                          return 'Telefone incompleto';
                         }
                         return null;
                       },
@@ -135,10 +240,16 @@ class _EditUserProfilePageState extends State<EditUserProfilePage> {
                       controller: _birthdateController,
                       label: 'Data de Nascimento',
                       icon: Icons.calendar_today_outlined,
+                      keyboardType: TextInputType.datetime,
+                      inputFormatters: [_dateMask],
                       hint: 'DD/MM/YYYY',
                       validator: (value) {
                         if (value?.isEmpty ?? true) {
                           return 'Data de nascimento é obrigatória';
+                        }
+                        final clean = value!.replaceAll(RegExp(r'\D'), '');
+                        if (clean.length != 8) {
+                          return 'Data incompleta';
                         }
                         return null;
                       },
@@ -160,9 +271,6 @@ class _EditUserProfilePageState extends State<EditUserProfilePage> {
                       validator: (value) {
                         if (_passwordController.text.isNotEmpty && (value?.isEmpty ?? true)) {
                           return 'Insira sua senha atual para alterar';
-                        }
-                        if (_passwordController.text.isNotEmpty && value != '123456') {
-                          return 'Senha atual incorreta';
                         }
                         return null;
                       },
@@ -199,16 +307,16 @@ class _EditUserProfilePageState extends State<EditUserProfilePage> {
                 ),
                 const SizedBox(height: 32),
                 PrimaryButton(
-                  text: _isLoading ? 'Salvando...' : 'Salvar Alterações',
-                  isLoading: _isLoading,
-                  onPressed: _savProfile,
+                  text: (_isLoading || _isLoadingPassword) ? 'Salvando...' : 'Salvar Alterações',
+                  isLoading: _isLoading || _isLoadingPassword,
+                  onPressed: (_isLoading || _isLoadingPassword) ? null : _handleSave,
                 ),
                 const SizedBox(height: 16),
                 SizedBox(
                   width: double.infinity,
                   height: 48,
                   child: OutlinedButton(
-                    onPressed: () => context.pop(),
+                    onPressed: (_isLoading || _isLoadingPassword) ? null : () => context.pop(),
                     style: OutlinedButton.styleFrom(
                       side: const BorderSide(color: AppColors.primary),
                       shape: RoundedRectangleBorder(
@@ -241,12 +349,16 @@ class _EditUserProfilePageState extends State<EditUserProfilePage> {
     TextInputType keyboardType = TextInputType.text,
     int maxLines = 1,
     String? hint,
+    List<TextInputFormatter>? inputFormatters,
+    void Function(String)? onChanged,
     String? Function(String?)? validator,
   }) {
     return TextFormField(
       controller: controller,
       keyboardType: keyboardType,
       maxLines: maxLines,
+      inputFormatters: inputFormatters,
+      onChanged: onChanged,
       minLines: maxLines == 1 ? 1 : maxLines,
       validator: validator,
       style: const TextStyle(
@@ -342,6 +454,42 @@ class _EditUserProfilePageState extends State<EditUserProfilePage> {
           vertical: 16,
         ),
       ),
+    );
+  }
+}
+
+class _BrazilianPhoneFormatter extends TextInputFormatter {
+  @override
+  TextEditingValue formatEditUpdate(
+    TextEditingValue oldValue,
+    TextEditingValue newValue,
+  ) {
+    final text = newValue.text.replaceAll(RegExp(r'\D'), '');
+    if (text.length > 11) return oldValue;
+
+    String formatted = '';
+    if (text.isNotEmpty) {
+      formatted += '(';
+      formatted += text.substring(0, text.length > 2 ? 2 : text.length);
+      if (text.length > 2) {
+        formatted += ') ';
+        if (text.length <= 10) {
+          formatted += text.substring(2, text.length > 6 ? 6 : text.length);
+          if (text.length > 6) {
+            formatted += '-';
+            formatted += text.substring(6);
+          }
+        } else {
+          formatted += text.substring(2, 7);
+          formatted += '-';
+          formatted += text.substring(7);
+        }
+      }
+    }
+
+    return TextEditingValue(
+      text: formatted,
+      selection: TextSelection.collapsed(offset: formatted.length),
     );
   }
 }

--- a/Frontend/lib/features/profile/presentation/pages/user_profile_page.dart
+++ b/Frontend/lib/features/profile/presentation/pages/user_profile_page.dart
@@ -1,78 +1,104 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import '../../../../core/theme/app_colors.dart';
 import '../../../../core/widgets/primary_button.dart';
+import '../providers/user_profile_provider.dart';
 import '../widgets/profile_header.dart';
 import '../widgets/profile_menu_item.dart';
 
-class UserProfilePage extends StatelessWidget {
+class UserProfilePage extends ConsumerWidget {
   const UserProfilePage({super.key});
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
+    final profileAsync = ref.watch(userProfileProvider);
+
     return Scaffold(
       backgroundColor: AppColors.backgroundLight,
       body: SafeArea(
-        child: SingleChildScrollView(
-          padding: const EdgeInsets.symmetric(horizontal: 24.0),
-          child: Column(
-            children: [
-              const SizedBox(height: 120), // Accounting for CustomAppBar
-              ProfileHeader(
-                name: 'Acesse agora', // Placeholder name from prototype
-                email: 'usuario@user.com',
-                onEditTap: () => context.push('/profile/user/edit'),
-              ),
-              const SizedBox(height: 32),
-              ProfileMenuSection(
-                title: 'Atividade',
-                items: [
-                  ProfileMenuItem(
-                    title: 'notificações',
-                    icon: Icons.notifications_none,
-                    onTap: () => context.go('/notifications'),
+        child: profileAsync.when(
+          loading: () => const Center(child: CircularProgressIndicator()),
+          error: (error, _) => Center(
+            child: Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 32.0),
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  Text(
+                    error.toString().replaceFirst('Exception: ', ''),
+                    textAlign: TextAlign.center,
+                    style: const TextStyle(color: AppColors.primary),
                   ),
-                  ProfileMenuItem(
-                    title: 'meus tickets',
-                    icon: Icons.confirmation_number_outlined,
-                    onTap: () => context.go('/tickets'),
-                  ),
-                  ProfileMenuItem(
-                    title: 'favoritos',
-                    icon: Icons.favorite_border,
-                    onTap: () => context.go('/favorites'),
-                    showDivider: false,
+                  const SizedBox(height: 16),
+                  ElevatedButton(
+                    onPressed: () => ref.invalidate(userProfileProvider),
+                    child: const Text('Tentar novamente'),
                   ),
                 ],
               ),
-              const SizedBox(height: 24),
-              ProfileMenuSection(
-                title: 'sistema',
-                items: [
-                  ProfileMenuItem(
-                    title: 'configurações',
-                    icon: Icons.settings_outlined,
-                    onTap: () {
-                      context.push('/profile/settings');
-                    },
-                  ),
-                  ProfileMenuItem(
-                    title: 'suporte',
-                    icon: Icons.headset_mic_outlined,
-                    onTap: () {},
-                    showDivider: false,
-                  ),
-                ],
-              ),
-              const SizedBox(height: 32),
-              PrimaryButton(
-                text: 'sair',
-                color: AppColors.secondary,
-                textColor: AppColors.primary,
-                onPressed: () => context.go('/auth'),
-              ),
-              const SizedBox(height: 40),
-            ],
+            ),
+          ),
+          data: (profile) => SingleChildScrollView(
+            padding: const EdgeInsets.symmetric(horizontal: 24.0),
+            child: Column(
+              children: [
+                const SizedBox(height: 120),
+                ProfileHeader(
+                  name: profile.nomeCompleto,
+                  email: profile.email,
+                  avatarUrl: profile.fotoPerfil,
+                  onEditTap: () => context.push('/profile/user/edit'),
+                ),
+                const SizedBox(height: 32),
+                ProfileMenuSection(
+                  title: 'Atividade',
+                  items: [
+                    ProfileMenuItem(
+                      title: 'notificações',
+                      icon: Icons.notifications_none,
+                      onTap: () => context.go('/notifications'),
+                    ),
+                    ProfileMenuItem(
+                      title: 'meus tickets',
+                      icon: Icons.confirmation_number_outlined,
+                      onTap: () => context.go('/tickets'),
+                    ),
+                    ProfileMenuItem(
+                      title: 'favoritos',
+                      icon: Icons.favorite_border,
+                      onTap: () => context.go('/favorites'),
+                      showDivider: false,
+                    ),
+                  ],
+                ),
+                const SizedBox(height: 24),
+                ProfileMenuSection(
+                  title: 'sistema',
+                  items: [
+                    ProfileMenuItem(
+                      title: 'configurações',
+                      icon: Icons.settings_outlined,
+                      onTap: () => context.push('/profile/settings'),
+                    ),
+                    ProfileMenuItem(
+                      title: 'suporte',
+                      icon: Icons.headset_mic_outlined,
+                      onTap: () {},
+                      showDivider: false,
+                    ),
+                  ],
+                ),
+                const SizedBox(height: 32),
+                PrimaryButton(
+                  text: 'sair',
+                  color: AppColors.secondary,
+                  textColor: AppColors.primary,
+                  onPressed: () => context.go('/auth'),
+                ),
+                const SizedBox(height: 40),
+              ],
+            ),
           ),
         ),
       ),

--- a/Frontend/lib/features/profile/presentation/providers/user_profile_provider.dart
+++ b/Frontend/lib/features/profile/presentation/providers/user_profile_provider.dart
@@ -1,0 +1,27 @@
+import 'dart:async';
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../data/models/user_profile_model.dart';
+import '../../../../utils/Usuario.dart';
+
+class UserProfileNotifier extends AsyncNotifier<UserProfileModel> {
+  @override
+  Future<UserProfileModel> build() async {
+    final completer = Completer<UserProfileModel>();
+
+    ref.read(usuarioServiceProvider).getAutenticado(
+      onSuccess: (data) =>
+          completer.complete(UserProfileModel.fromJson(data)),
+      onError: (message) =>
+          completer.completeError(Exception(message)),
+    );
+
+    return completer.future;
+  }
+}
+
+final userProfileProvider =
+    AsyncNotifierProvider<UserProfileNotifier, UserProfileModel>(
+  UserProfileNotifier.new,
+);

--- a/Frontend/lib/utils/Usuario.dart
+++ b/Frontend/lib/utils/Usuario.dart
@@ -62,12 +62,11 @@ class UsuarioService {
       return;
     }
 
-    String? cleanCelular;
+    // No backend, o celular deve vir com máscara: (xx) xxxxx-xxxx
     if (numeroCelular != null && numeroCelular.isNotEmpty) {
-      cleanCelular = numeroCelular.replaceAll(RegExp(r'[^\d]'), '');
-      if (cleanCelular.length != 11) {
+      if (!RegExp(r'^\(\d{2}\) \d{4,5}-\d{4}$').hasMatch(numeroCelular)) {
         onError(
-          'Número de celular deve conter exatamente 11 números (com DDD).',
+          'Celular inválido: formato esperado (xx) xxxx-xxxx ou (xx) xxxxx-xxxx',
         );
         return;
       }
@@ -82,7 +81,7 @@ class UsuarioService {
           'senha': senha,
           'cpf': cleanCpf,
           'data_nascimento': dataNascimento.trim(),
-          if (cleanCelular != null) 'numero_celular': cleanCelular,
+          if (numeroCelular != null) 'numero_celular': numeroCelular,
         },
       );
       onSuccess(response.data!['data'] as Map<String, dynamic>);
@@ -204,12 +203,11 @@ class UsuarioService {
       return;
     }
 
-    String? cleanCelular;
+    // No backend, o celular deve vir com máscara: (xx) xxxxx-xxxx
     if (numeroCelular != null && numeroCelular.trim().isNotEmpty) {
-      cleanCelular = numeroCelular.replaceAll(RegExp(r'[^\d]'), '');
-      if (cleanCelular.length != 11) {
+      if (!RegExp(r'^\(\d{2}\) \d{4,5}-\d{4}$').hasMatch(numeroCelular)) {
         onError(
-          'Número de celular deve conter exatamente 11 números (com DDD).',
+          'Celular inválido: formato esperado (xx) xxxx-xxxx ou (xx) xxxxx-xxxx',
         );
         return;
       }
@@ -221,7 +219,8 @@ class UsuarioService {
       if (email != null && email.trim().isNotEmpty) 'email': email.trim(),
       if (dataNascimento != null && dataNascimento.trim().isNotEmpty)
         'data_nascimento': dataNascimento.trim(),
-      if (cleanCelular != null) 'numero_celular': cleanCelular,
+      if (numeroCelular != null && numeroCelular.trim().isNotEmpty)
+        'numero_celular': numeroCelular,
     };
 
     if (data.isEmpty) {

--- a/P3-C-edit-user-profile-page.md
+++ b/P3-C-edit-user-profile-page.md
@@ -1,0 +1,79 @@
+# P3-C — edit_user_profile_page - feat/update-guest-profile
+
+## Tela
+`lib/features/profile/presentation/pages/edit_user_profile_page.dart`
+
+## Prioridade
+**P3 — Perfil (Feature média)**
+
+## Branch sugerida
+`feat/edit-user-profile-page-integration`
+
+---
+
+## Estado Atual
+Tela **existe e está implementada** (StatefulWidget com UI completa).
+
+Seções já construídas:
+- **Informações pessoais:** Nome, Email, Telefone, Data de nascimento
+- **Segurança:** Senha atual, Nova senha, Confirmar nova senha
+- Botões **Salvar** e **Cancelar** (com loading state)
+
+Sem integração real com API:
+- `initState` popula campos com dados hardcoded (`"Acesse agora"`, `"usuario@user.com"`)
+- Submit usa `Future.delayed(1 second)` como mock
+- Validação de senha verifica contra `'123456'` hardcoded
+
+---
+
+## O que integrar
+
+### Pré-população dos campos
+- [ ] Remover dados hardcoded do `initState`
+- [ ] Pré-popular campos com dados do `UserProfileNotifier` (P3-A) ao carregar a tela
+
+### Salvar dados pessoais
+- [ ] Conectar o submit ao `PATCH /usuarios/me` com os campos alterados:
+  - `nome`, `email`, `telefone`, `data_nascimento`
+- [ ] Tratar resposta de sucesso:
+  - [ ] Atualizar estado no `UserProfileNotifier`
+  - [ ] Exibir snackbar de sucesso
+  - [ ] Navegar de volta para `user_profile_page`
+- [ ] Tratar erros:
+  - [ ] Email duplicado (409)
+  - [ ] Dados inválidos (400)
+
+### Troca de senha (seção já na tela)
+- [ ] Remover validação hardcoded contra `'123456'`
+- [ ] Ao submeter com campos de senha preenchidos, chamar `POST /usuarios/change-password`
+  - Body: `senha_atual`, `nova_senha`
+- [ ] Validação local: `nova_senha === confirmar_nova_senha`
+- [ ] Tratar erro de senha atual incorreta (401/400)
+- [ ] Feedback de sucesso separado para a troca de senha
+
+### Upload de foto de perfil
+- [ ] ⚠️ Verificar se existe campo de foto na tela — se sim, verificar se o backend tem endpoint de upload para avatar de usuário
+- [ ] Se não existir endpoint no back → levantar task EXT
+
+---
+
+## Endpoints usados
+
+| Método | Rota                         | Auth | Descrição              |
+|--------|------------------------------|------|------------------------|
+| PATCH  | `/usuarios/me`               | ✅   | Atualizar dados guest  |
+| POST   | `/usuarios/change-password`  | ✅   | Trocar senha guest     |
+
+---
+
+## Dependências
+- **Requer:** P3-A (`user_profile_page` com dados carregados no notifier)
+
+## Bloqueia
+— (folha)
+
+---
+
+## Observações
+- A tela **já existe** com UI completa — foco total em substituir mocks por integração real.
+- A seção de segurança já está implementada na tela, não precisa ser criada.

--- a/conductor/features/edit-user-profile-page.prd.md
+++ b/conductor/features/edit-user-profile-page.prd.md
@@ -1,0 +1,104 @@
+# PRD — edit-user-profile-page
+
+> **Feature ID:** P3-C  
+> **Branch:** `feat/edit-user-profile-page-integration`  
+> **Prioridade:** P3 — Perfil (Feature média)  
+> **Arquivo alvo:** `lib/features/profile/presentation/pages/edit_user_profile_page.dart`
+
+---
+
+## Contexto
+
+A tela `edit_user_profile_page.dart` já existe na aplicação Flutter com UI completa (StatefulWidget). Ela contém seções para edição de **informações pessoais** (nome, email, telefone, data de nascimento) e **segurança** (senha atual, nova senha, confirmar nova senha), além dos botões Salvar e Cancelar com loading state.
+
+O problema atual é que toda a lógica de dados é fictícia: o `initState` popula os campos com strings hardcoded, o submit usa `Future.delayed(1 second)` como mock, e a validação de senha compara contra a string literal `'123456'`. Não há comunicação real com o backend.
+
+Esta feature depende de **P3-A** (`user_profile_page` com `UserProfileNotifier` em funcionamento) para que os dados do usuário autenticado estejam disponíveis em memória ao carregar a tela.
+
+---
+
+## Problema
+
+A tela de edição de perfil não persiste nenhuma alteração real. O usuário preenche os campos e clica em "Salvar", mas nenhuma chamada de API ocorre — os dados voltam ao estado inicial ao recarregar a tela. A validação de senha retorna falsos positivos/negativos por comparar com um valor fixo. Isso impede que a feature de perfil seja funcional para o usuário final.
+
+---
+
+## Público-alvo
+
+**Usuários finais (guests)** autenticados na plataforma ReservAqui que desejam manter seus dados pessoais atualizados ou trocar de senha.
+
+---
+
+## Requisitos Funcionais
+
+1. Ao abrir a tela, os campos de informações pessoais devem ser pré-populados com os dados reais do usuário, provenientes do `UserProfileNotifier` (P3-A).
+2. O usuário deve conseguir editar nome, email, telefone e data de nascimento e salvar as alterações via `PATCH /usuarios/me`.
+3. Ao salvar com sucesso, o `UserProfileNotifier` deve ser atualizado com os novos dados retornados pelo backend.
+4. Ao salvar com sucesso, um snackbar de confirmação deve ser exibido e a navegação deve retornar para `user_profile_page`.
+5. O sistema deve tratar e exibir erros de negócio retornados pelo backend: e-mail duplicado (HTTP 409) e dados inválidos (HTTP 400).
+6. Caso os campos de senha estejam preenchidos, o sistema deve chamar `POST /usuarios/change-password` com `senha_atual` e `nova_senha`.
+7. A validação local deve garantir que `nova_senha` e `confirmar_nova_senha` sejam idênticas antes de enviar a requisição.
+8. A validação hardcoded contra `'123456'` deve ser removida por completo.
+9. O sistema deve tratar o erro de senha atual incorreta (HTTP 401 / 400) e exibir mensagem de erro específica na seção de segurança.
+10. O feedback de sucesso da troca de senha deve ser separado e independente do feedback de atualização dos dados pessoais.
+11. Verificar se existe campo de foto de perfil na tela; se existir e o backend não possuir endpoint de upload de avatar, levantar task EXT antes de implementar.
+
+---
+
+## Requisitos Não-Funcionais
+
+- [x] **Performance:** As chamadas de API devem utilizar o padrão existente com Dio (`API_functions.dart`); o loading state visual já implementado nos botões deve encapsular o estado das requisições.
+- [x] **Segurança:** Todos os endpoints requerem autenticação. O token JWT do usuário logado deve ser enviado via interceptor do Dio. Nenhuma senha deve ser logada ou armazenada em plain text.
+- [x] **Acessibilidade:** Campos de formulário devem manter os labels e semântica já existentes; mensagens de erro devem ser associadas aos campos correspondentes.
+- [x] **Responsividade:** A tela já é mobile-first (Flutter); manter responsividade atual — nenhuma mudança de layout é esperada.
+- [x] **Estado Global:** A atualização dos dados deve refletir imediatamente no `UserProfileNotifier` para que outras telas que dependem desse estado sejam sincronizadas sem necessidade de refresh.
+
+---
+
+## Critérios de Aceitação
+
+- Dado que o usuário está autenticado e navega para a tela de edição, quando a tela carregar, então os campos nome, email, telefone e data de nascimento devem exibir os valores reais do usuário (do `UserProfileNotifier`), **não** strings hardcoded.
+- Dado que o usuário alterou seu nome e clicou em "Salvar", quando a requisição `PATCH /usuarios/me` for concluída com sucesso, então o `UserProfileNotifier` deve ter o estado atualizado, um snackbar verde de sucesso deve aparecer e a tela deve navegar de volta para `user_profile_page`.
+- Dado que o usuário tenta salvar um e-mail já cadastrado por outro usuário, quando o backend retornar HTTP 409, então a UI deve exibir uma mensagem de erro legível ao usuário (ex: "Este e-mail já está em uso.") sem travar a tela.
+- Dado que o usuário preencheu a seção de senha e `nova_senha != confirmar_nova_senha`, quando tentar submeter, então a validação local deve bloquear o envio e exibir mensagem de erro nos campos correspondentes.
+- Dado que o usuário preencheu corretamente os três campos de senha e clicou em "Salvar", quando a requisição `POST /usuarios/change-password` for concluída com sucesso, então um snackbar específico de confirmação de troca de senha deve ser exibido e os campos de senha devem ser limpos.
+- Dado que o usuário informou a senha atual incorretamente, quando o backend retornar HTTP 401 ou 400, então a UI deve exibir uma mensagem de erro específica na seção de segurança (ex: "Senha atual incorreta.") sem afetar a seção de dados pessoais.
+- Dado qualquer cenário de submissão, quando a requisição estiver em andamento, então os botões Salvar e Cancelar devem exibir o loading state e estar desabilitados para evitar submissões duplas.
+
+---
+
+## Fora de Escopo
+
+- Criação ou redesign de qualquer elemento visual da tela (a UI já está completa).
+- Upload de foto/avatar de perfil (depende de verificação de endpoint no backend — se não existir, uma task EXT separada será criada).
+- Notificações por e-mail ao trocar de senha.
+- Histórico ou auditoria de alterações de perfil.
+- Fluxo de recuperação de senha ("esqueci minha senha") — é um fluxo separado de autenticação.
+- Qualquer alteração na tela de perfil de **estabelecimentos/admins** (escopo restrito ao perfil do guest).
+- Testes E2E automatizados (serão tratados em task de QA separada).
+
+---
+
+## Dependências
+
+| Direção | Task | Descrição |
+|---------|------|-----------|
+| **Requer** | P3-A | `UserProfileNotifier` populado com dados reais do usuário autenticado |
+
+---
+
+## Endpoints Consumidos
+
+| Método | Rota | Auth | Descrição |
+|--------|------|------|-----------|
+| `PATCH` | `/usuarios/me` | ✅ JWT | Atualizar dados pessoais do guest |
+| `POST` | `/usuarios/change-password` | ✅ JWT | Trocar senha do guest |
+
+---
+
+## Referências
+
+- Task original: [`P3-C-edit-user-profile-page.md`](../../P3-C-edit-user-profile-page.md)
+- Arquivo alvo: `Frontend/lib/features/profile/presentation/pages/edit_user_profile_page.dart`
+- Skill de bridge de API: `.agent/skills/flutter-api-bridge/SKILL.md`
+- Coleção Postman: `ReservAqui.postman_collection.json`

--- a/conductor/features/user-profile-page.prd.md
+++ b/conductor/features/user-profile-page.prd.md
@@ -1,0 +1,42 @@
+# PRD — User Profile Page (get-guest-profile)
+
+## Contexto
+A tela de perfil do hóspede (`lib/features/profile/presentation/pages/user_profile_page.dart`) existe no app mas exibe dados hardcoded ou mockados. O backend já expõe o endpoint `GET /usuarios/me` para retornar os dados do usuário autenticado, e o interceptor de autenticação (P0) já está em funcionamento.
+
+## Problema
+O usuário autenticado não visualiza seus dados reais na tela de perfil. Sem integração com o backend, informações como nome, e-mail e foto são fictícias, prejudicando a confiança e a experiência do usuário.
+
+## Público-alvo
+Usuários hóspedes autenticados no aplicativo Reserva Aqui.
+
+## Requisitos Funcionais
+1. Ao entrar na tela, realizar `GET /usuarios/me` para buscar os dados do usuário autenticado.
+2. Mapear a resposta da API para os widgets da tela (nome, e-mail, foto de perfil, etc.).
+3. Criar `UserProfileNotifier` (Riverpod) para gerenciar e expor o estado do perfil.
+4. Exibir indicador de carregamento (loading state) enquanto a requisição está em andamento.
+5. Tratar erros de rede; erros 401 (token expirado) devem ser capturados pelo interceptor do P0.
+6. O botão "Editar perfil" deve navegar para `edit_user_profile_page` (P3-C).
+7. O botão "Configurações" deve navegar para `settings_page` (P3-E).
+8. Exibir avatar padrão quando o backend não retornar URL de foto de perfil.
+
+## Requisitos Não-Funcionais
+- [ ] Segurança: requisição autenticada via Bearer token; refresh/logout tratado pelo interceptor P0
+- [ ] Performance: feedback visual imediato (shimmer ou CircularProgressIndicator) durante o fetch
+- [ ] Responsividade: funcionar corretamente em dispositivos móveis (Flutter)
+- [ ] Resiliência: exibir mensagem de erro amigável em caso de falha de rede, com opção de tentar novamente
+
+## Critérios de Aceitação
+- Dado que o usuário está autenticado, quando abrir a tela de perfil, então deve ver seus dados reais (nome, e-mail) carregados do backend.
+- Dado que a requisição está em andamento, quando a tela abrir, então deve exibir um indicador de carregamento.
+- Dado que o backend não retorna foto de perfil, quando os dados forem carregados, então deve exibir um avatar padrão.
+- Dado que ocorre erro de rede, quando a tela tentar carregar o perfil, então deve exibir mensagem de erro com opção de retry.
+- Dado que o token está expirado (401), quando a requisição for feita, então o interceptor P0 deve redirecionar para o login.
+- Dado que o usuário clica em "Editar perfil", quando na tela de perfil, então deve navegar para `edit_user_profile_page`.
+- Dado que o usuário clica em "Configurações", quando na tela de perfil, então deve navegar para `settings_page`.
+
+## Fora de Escopo
+- Edição dos dados do perfil (cobre P3-C — `edit_user_profile_page`)
+- Tela de configurações (cobre P3-E — `settings_page`)
+- Upload ou alteração de foto de perfil
+- Exclusão de conta
+- Notificações por e-mail ou push relacionadas ao perfil

--- a/conductor/plan.md
+++ b/conductor/plan.md
@@ -45,6 +45,7 @@
   - [x] CEP autofill no cadastro de hotel (cep-autofill) — plan: plans/cep-autofill.plan.md
 - [ ] Tela de esqueci minha senha
 - [ ] Sessão persistente no app (armazenar token localmente)
+- [ ] Tela de perfil do hóspede (P3-A) — plan: plans/user-profile-page.plan.md
 
 ---
 

--- a/conductor/plans/edit-user-profile-page.plan.md
+++ b/conductor/plans/edit-user-profile-page.plan.md
@@ -1,0 +1,113 @@
+# Plan — Edit User Profile Page (P3-C)
+
+> Derivado de: conductor/specs/edit-user-profile-page.spec.md
+> Status geral: [PENDENTE]
+
+---
+
+## Setup & Infraestrutura [CONCLUÍDO]
+
+> Todas as dependências, services, providers e models já estão no projeto — nenhuma instalação ou criação de arquivo de infra necessária.
+
+- [x] `flutter_riverpod` disponível no pubspec
+- [x] `dio` + `dioProvider` configurados em `lib/core/network/dio_client.dart`
+- [x] `go_router` com rota `/profile/user/edit` definida em `lib/core/router/app_router.dart`
+- [x] `UserProfileModel` implementado em `lib/features/profile/data/models/user_profile_model.dart`
+- [x] `userProfileProvider` + `UserProfileNotifier` implementados em `lib/features/profile/presentation/providers/user_profile_provider.dart`
+- [x] `usuarioServiceProvider.update()` implementado em `lib/utils/Usuario.dart` (linhas 185–247)
+- [x] `usuarioServiceProvider.changePassword()` implementado em `lib/utils/Usuario.dart` (linhas 254–294)
+
+---
+
+## Backend [CONCLUÍDO]
+
+> Nenhuma alteração necessária — ambos os endpoints já existem e estão em produção.
+
+- [x] Endpoint `PATCH /usuarios/me` autenticado via Bearer token — atualiza nome, email, celular e data de nascimento
+- [x] Endpoint `POST /usuarios/change-password` autenticado via Bearer token — troca a senha e invalida refresh tokens
+
+---
+
+## Frontend [PENDENTE]
+
+### 1. Converter tipo do widget
+
+- [ ] Alterar `EditUserProfilePage` de `StatefulWidget` para `ConsumerStatefulWidget`
+  - Trocar `State<EditUserProfilePage>` por `ConsumerState<EditUserProfilePage>`
+  - Adicionar import de `flutter_riverpod`
+
+### 2. Adicionar estado de loading de senha
+
+- [ ] Declarar `bool _isLoadingPassword = false;` ao lado do `_isLoading` existente
+  - `_isLoading` → cobre o submit de dados pessoais
+  - `_isLoadingPassword` → cobre o submit de troca de senha
+
+### 3. Corrigir initState — remover dados hardcoded
+
+- [ ] Substituir `TextEditingController(text: 'Acesse agora')` por `TextEditingController(text: profile?.nomeCompleto ?? '')`
+- [ ] Substituir `TextEditingController(text: 'usuario@user.com')` por `TextEditingController(text: profile?.email ?? '')`
+- [ ] Pré-popular `_phoneController` com `profile?.numeroCelular ?? ''`
+- [ ] Pré-popular `_birthdateController` com `profile?.dataNascimento ?? ''`
+  - ⚠️ Se `dataNascimento` vier do backend em `YYYY-MM-DD`, converter para `dd/mm/aaaa` antes de popular
+- [ ] Leitura via `ref.read(userProfileProvider).valueOrNull` (não `ref.watch` — leitura única no `initState`)
+
+### 4. Implementar `_savePersonalData()`
+
+- [ ] Renomear / substituir o método `_savProfile()` por `_savePersonalData()`
+- [ ] Remover o `Future.delayed(const Duration(seconds: 1))` (mock)
+- [ ] Chamar `ref.read(usuarioServiceProvider).update(...)` com os valores dos controllers:
+  - `nomeCompleto: _nameController.text`
+  - `email: _emailController.text`
+  - `numeroCelular: _phoneController.text`
+  - `dataNascimento: _birthdateController.text`
+- [ ] No `onSuccess`: chamar `ref.invalidate(userProfileProvider)`, exibir `SnackBar` de sucesso e `context.pop()`
+- [ ] No `onError`: exibir `SnackBar` com a mensagem de erro retornada pelo service
+- [ ] Envolver em `try/finally` garantindo `setState(() => _isLoading = false)` sempre ao fim
+
+### 5. Implementar `_savePassword()`
+
+- [ ] Criar método `Future<void> _savePassword()` independente
+- [ ] Acionar apenas se `_passwordController.text.isNotEmpty`
+- [ ] Chamar `ref.read(usuarioServiceProvider).changePassword(...)`:
+  - `senhaAtual: _currentPasswordController.text`
+  - `novaSenha: _passwordController.text`
+  - `confirmarNovaSenha: _confirmPasswordController.text`
+- [ ] No `onSuccess`: limpar os três campos de senha e exibir `SnackBar` de confirmação independente
+- [ ] No `onError`: exibir `SnackBar` com a mensagem de erro (ex: `"A senha atual está incorreta ou sua sessão expirou."`)
+- [ ] Usar `_isLoadingPassword` para controlar o estado de loading desta operação
+
+### 6. Unificar o submit no botão "Salvar"
+
+- [ ] Atualizar `onPressed` do `PrimaryButton` para chamar sequencialmente:
+  1. `_savePersonalData()` — sempre (se o form for válido)
+  2. `_savePassword()` — apenas se `_passwordController.text.isNotEmpty`
+- [ ] Desabilitar o botão "Salvar" e "Cancelar" enquanto `_isLoading || _isLoadingPassword`
+
+### 7. Corrigir validator da senha atual
+
+- [ ] Remover a linha `if (_passwordController.text.isNotEmpty && value != '123456')` do validator de `_currentPasswordController`
+- [ ] Manter apenas: se `_passwordController.text.isNotEmpty && (value?.isEmpty ?? true)` → `'Insira sua senha atual para alterar'`
+- [ ] A validação real da senha atual é feita pelo backend via `changePassword()`
+
+---
+
+## Validação [PENDENTE]
+
+- [ ] Dado que o usuário está autenticado e o P3-A carregou os dados, ao abrir `/profile/user/edit`, os campos nome, email, telefone e data de nascimento devem exibir os dados reais do usuário (não `"Acesse agora"` ou `"usuario@user.com"`)
+- [ ] Dado que o usuário altera o nome e clica em "Salvar", a requisição `PATCH /usuarios/me` é disparada; ao retornar 200, o `userProfileProvider` é invalidado, um snackbar verde aparece e a tela volta para `UserProfilePage` exibindo o nome atualizado
+- [ ] Dado que o usuário tenta salvar um e-mail já cadastrado, o backend retorna 409 e a tela exibe a mensagem `"O e-mail informado já está em uso por outra conta."` sem fechar ou congelar
+- [ ] Dado que `nova_senha !== confirmar_nova_senha`, o form bloqueia o submit com mensagem de erro inline no campo `"Confirmar Senha"`, sem chamar nenhuma API
+- [ ] Dado que os três campos de senha estão preenchidos corretamente, a requisição `POST /usuarios/change-password` é disparada; ao retornar 200, os três campos de senha são limpos e um snackbar específico de confirmação de senha é exibido
+- [ ] Dado que a senha atual está incorreta, o backend retorna 401/400 e a tela exibe `"A senha atual está incorreta ou sua sessão expirou."` sem afetar os campos de dados pessoais
+- [ ] Dado que qualquer requisição está em andamento, os botões "Salvar Alterações" e "Cancelar" estão desabilitados (sem duplo submit)
+- [ ] Dado que o P3-A ainda não carregou (AsyncLoading), a tela abre com os campos vazios sem crash; o usuário pode preencher manualmente
+- [ ] A validação hardcoded contra `'123456'` foi completamente removida e não causa mais falsos positivos/negativos
+
+---
+
+## Sincronização com plan.md
+
+> Quando todas as seções acima estiverem `[CONCLUÍDO]`, atualizar `conductor/plan.md`:
+> - Localizar o bloco de P3-C ou `edit-user-profile-page`
+> - Marcar o status como `[CONCLUÍDO]`
+> - Se não existir, criar nova fase com tasks resumidas e status `[CONCLUÍDO]`

--- a/conductor/plans/user-profile-page.plan.md
+++ b/conductor/plans/user-profile-page.plan.md
@@ -1,0 +1,51 @@
+# Plan — User Profile Page (P3-A)
+
+> Derivado de: conductor/specs/user-profile-page.spec.md
+> Status geral: [PENDENTE]
+
+---
+
+## Setup & Infraestrutura [CONCLUÍDO]
+
+> Todas as dependências já estão no projeto — nenhuma instalação necessária.
+
+- [x] `flutter_riverpod` disponível no pubspec
+- [x] `dio` + `dioProvider` configurados em `lib/core/network/dio_client.dart`
+- [x] `go_router` com rota `/profile/user` definida em `lib/core/router/app_router.dart`
+- [x] `usuarioServiceProvider.getAutenticado()` implementado em `lib/utils/Usuario.dart`
+
+---
+
+## Backend [CONCLUÍDO]
+
+> Nenhuma alteração necessária — endpoint `GET /usuarios/me` já existe e está em produção.
+
+- [x] Endpoint `GET /usuarios/me` autenticado via Bearer token
+
+---
+
+## Frontend [CONCLUÍDO]
+
+- [x] Criar `UserProfileModel` com `fromJson` em `lib/features/profile/data/models/user_profile_model.dart`
+  - Campos: `id`, `nomeCompleto`, `email`, `cpf?`, `numeroCelular?`, `fotoPerfil?`, `dataNascimento?`
+  - Usar `json['id'].toString()` para suportar `id` como `int` ou `String`
+- [x] Criar `UserProfileNotifier` (`AsyncNotifier<UserProfileModel>`) em `lib/features/profile/presentation/providers/user_profile_provider.dart`
+  - `build()`: chama `usuarioServiceProvider.getAutenticado()` e retorna `UserProfileModel.fromJson(data)`
+  - Expor `userProfileProvider` via `AsyncNotifierProvider`
+- [x] Converter `UserProfilePage` de `StatelessWidget` para `ConsumerWidget` em `lib/features/profile/presentation/pages/user_profile_page.dart`
+  - Adicionar `ref.watch(userProfileProvider)` no início do `build()`
+  - Tratar `AsyncLoading` → `Center(CircularProgressIndicator())`
+  - Tratar `AsyncData` → passar `model.nomeCompleto`, `model.email`, `model.fotoPerfil` para `ProfileHeader`
+  - Tratar `AsyncError` → exibir mensagem + `ElevatedButton('Tentar novamente', onPressed: () => ref.invalidate(userProfileProvider))`
+
+---
+
+## Validação [PENDENTE]
+
+- [ ] Dado que o usuário está autenticado, ao abrir `/profile/user`, os dados reais (nome e e-mail) retornados por `GET /usuarios/me` são exibidos no `ProfileHeader`
+- [ ] Dado que a requisição ainda está em andamento, a tela exibe `CircularProgressIndicator` e não os dados hardcoded
+- [ ] Dado que o backend não retorna `foto_perfil`, o `ProfileHeader` exibe o ícone padrão (`Icons.person`) sem erros
+- [ ] Dado que ocorre erro de rede ou timeout, a tela exibe a mensagem de erro e o botão "Tentar novamente"; ao tocar no botão, o fetch é refeito
+- [ ] Dado que o token está expirado (401), o interceptor do P0 tenta o refresh; se falhar, o app redireciona para `/auth/login` sem exibir erro na tela de perfil
+- [ ] Ao tocar em "Editar perfil", o app navega para `/profile/user/edit`
+- [ ] Ao tocar em "Configurações", o app navega para `/profile/settings`

--- a/conductor/specs/edit-user-profile-page.spec.md
+++ b/conductor/specs/edit-user-profile-page.spec.md
@@ -1,0 +1,289 @@
+# Spec — Edit User Profile Page (P3-C)
+
+## Referência
+- **PRD:** `conductor/features/edit-user-profile-page.prd.md`
+- **Arquivo principal:** `Frontend/lib/features/profile/presentation/pages/edit_user_profile_page.dart`
+- **Branch:** `feat/edit-user-profile-page-integration`
+
+---
+
+## Abordagem Técnica
+
+Converter `EditUserProfilePage` de `StatefulWidget` puro para `ConsumerStatefulWidget` (Riverpod), mantendo toda a UI já construída (sem nenhuma mudança de layout) e substituindo os três pontos de mock por integração real:
+
+1. **`initState`:** eliminar strings hardcoded; pré-popular controllers com dados do `userProfileProvider` já em memória (P3-A precisa estar completo).
+2. **Submit de dados pessoais:** chamar `usuarioServiceProvider.update()` — método já implementado em `lib/utils/Usuario.dart` (linhas 185–247); em caso de sucesso, invalidar `userProfileProvider` e navegar com `context.pop()`.
+3. **Submit de senha:** chamar `usuarioServiceProvider.changePassword()` — também já implementado (linhas 254–294); em caso de sucesso, limpar os três campos de senha e exibir snackbar separado.
+
+> ⚡ **Nenhum novo service ou endpoint será criado.** Todo o código de rede já existe e está validado. O trabalho é unicamente de wiring (ligação) entre a UI e os métodos existentes.
+
+---
+
+## Componentes Afetados
+
+### Backend
+- **Nenhum.** Os dois endpoints (`PATCH /usuarios/me` e `POST /usuarios/change-password`) já existem e estão documentados.
+
+### Frontend
+
+| Tipo | Arquivo | O que muda |
+|------|---------|------------|
+| **Modificado** | `lib/features/profile/presentation/pages/edit_user_profile_page.dart` | Trocar `StatefulWidget` → `ConsumerStatefulWidget`; pré-popular controllers no `initState` com dados do `userProfileProvider`; substituir `Future.delayed` por chamadas reais aos services; remover validação hardcoded `'123456'`; separar fluxo de submit em dois (`_savePersonalData` + `_savePassword`); adicionar `_isLoadingPassword` separado |
+| **Sem alteração** | `lib/features/profile/presentation/providers/user_profile_provider.dart` | Já existe. Apenas `ref.invalidate(userProfileProvider)` será chamado após update bem-sucedido |
+| **Sem alteração** | `lib/features/profile/data/models/user_profile_model.dart` | Já existe com todos os campos necessários |
+| **Sem alteração** | `lib/utils/Usuario.dart` | `update()` e `changePassword()` já estão implementados |
+
+---
+
+## Decisões de Arquitetura
+
+| Decisão | Justificativa |
+|---------|---------------|
+| `ConsumerStatefulWidget` em vez de `ConsumerWidget` | A página tem estado local mutável (7 `TextEditingController`, 3 flags `_obscure*`, 2 flags `_isLoading`); `ConsumerStatefulWidget` é o tipo correto para formulários com Riverpod |
+| Dois métodos de submit separados (`_savePersonalData` / `_savePassword`) | Feedbacks independentes (PRD RF #10); evita acoplamento de estado de loading — `_isLoading` cobre dados pessoais, `_isLoadingPassword` cobre senha |
+| `ref.invalidate(userProfileProvider)` após update bem-sucedido | Força o re-fetch de `/usuarios/me` no provider; `UserProfilePage` (P3-A) re-renderiza automaticamente com dados frescos sem nenhum código extra |
+| Não criar `_isLoadingPersonal` + `_isLoadingPassword` como `StateProvider` | Riverpod é overkill para estado de UI local (loading de botão); `setState` é correto aqui — Riverpod gerencia apenas estado de rede e domínio |
+| Pré-popular no `initState` lendo `ref.read(userProfileProvider)` | O provider já foi carregado pela `UserProfilePage` (P3-A); `ref.read` (não `ref.watch`) no `initState` não causa rebuild — é o padrão correto para leitura única de inicialização |
+| `context.pop()` após save de dados pessoais (não `context.go`) | Mantém o stack de navegação; volta para `UserProfilePage` que exibe os dados atualizados via `ref.watch(userProfileProvider)` |
+| Campos de senha limpados após troca bem-sucedida | UX: evita reenvio acidental; confirmação visual de que a operação foi concluída |
+
+---
+
+## Contratos de API
+
+### `PATCH /usuarios/me` — Atualizar dados pessoais
+
+| Método | Rota | Auth | Body | Response (200) |
+|--------|------|------|------|----------------|
+| `PATCH` | `/usuarios/me` | Bearer JWT | `{ nome_completo?, email?, numero_celular?, data_nascimento? }` | `{ data: { id, nome_completo, email, cpf, numero_celular, foto_perfil, data_nascimento } }` |
+
+**Regras de campo (validação no service):**
+| Campo Flutter | Campo API | Formato esperado pelo backend |
+|---------------|-----------|-------------------------------|
+| `_nameController.text` | `nome_completo` | string livre |
+| `_emailController.text` | `email` | deve conter `@` e `.com` |
+| `_phoneController.text` | `numero_celular` | `(xx) xxxxx-xxxx` ou `(xx) xxxx-xxxx` |
+| `_birthdateController.text` | `data_nascimento` | `dd/mm/aaaa` |
+
+> ⚠️ O método `update()` do `UsuarioService` já aplica a máscara de celular (`replaceAll(RegExp(r'[^\d]'), '')`) e valida o formato antes de enviar.
+
+#### Erros tratados pelo `_handleDioError`
+| Status | Mensagem exibida |
+|--------|-----------------|
+| `400` | `"Dados inválidos. Verifique os campos e tente novamente."` |
+| `401` | `"Sessão expirada. Faça login novamente."` |
+| `409` | `"O e-mail informado já está em uso por outra conta."` |
+| timeout | `"Tempo de conexão esgotado. Verifique sua internet."` |
+
+---
+
+### `POST /usuarios/change-password` — Trocar senha
+
+| Método | Rota | Auth | Body | Response (200) |
+|--------|------|------|------|----------------|
+| `POST` | `/usuarios/change-password` | Bearer JWT | `{ senhaAtual: string, novaSenha: string }` | `{ message: "Senha alterada com sucesso. Faça login novamente." }` |
+
+> ⚠️ O método `changePassword()` já valida localmente: senhas não podem ser vazias, `novaSenha === confirmarNovaSenha`, e `novaSenha` deve atender a regex de complexidade (`/^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)(?=.*[^a-zA-Z\d])/`).
+
+#### Comportamento pós-sucesso
+- Trocar senha **invalida todos os refresh tokens** no backend.
+- Implicação: o usuário será deslogado na próxima vez que o `accessToken` expirar.
+- **Não** forçar logout imediato na UI (fora do escopo desta task).
+
+#### Erros tratados
+| Status | Mensagem exibida |
+|--------|-----------------|
+| `400` | `"Dados inválidos. Verifique as senhas e tente novamente."` |
+| `401` | `"A senha atual está incorreta ou sua sessão expirou."` |
+
+---
+
+## Modelos de Dados
+
+Nenhum model novo é criado. O `UserProfileModel` existente já cobre todos os campos necessários para pré-popular e atualizar o estado:
+
+```dart
+// lib/features/profile/data/models/user_profile_model.dart (existente — não alterar)
+class UserProfileModel {
+  final String id;
+  final String nomeCompleto;   // → _nameController
+  final String email;          // → _emailController
+  final String? cpf;           // read-only (não editável nesta tela)
+  final String? numeroCelular; // → _phoneController
+  final String? fotoPerfil;    // fora de escopo (P3-C)
+  final String? dataNascimento;// → _birthdateController
+}
+```
+
+---
+
+## Fluxo de Execução
+
+### Fluxo 1 — Inicialização
+
+```
+[Usuário navega para /profile/user/edit]
+       │
+       ▼
+[EditUserProfilePage.initState()]
+       │
+       ├─ ref.read(userProfileProvider)
+       │       └─ AsyncData(UserProfileModel)
+       │               ├─ _nameController.text     = model.nomeCompleto
+       │               ├─ _emailController.text    = model.email
+       │               ├─ _phoneController.text    = model.numeroCelular ?? ''
+       │               └─ _birthdateController.text = model.dataNascimento ?? ''
+       │
+       └─ AsyncLoading / AsyncError
+               └─ controllers iniciam vazios (fallback seguro)
+```
+
+### Fluxo 2 — Salvar Dados Pessoais
+
+```
+[Usuário clica em "Salvar Alterações"]
+       │
+       ▼
+[_formKey.currentState!.validate()]
+       │
+       ├─ inválido → exibe erros inline nos campos (Flutter Form nativo)
+       │
+       └─ válido
+               │
+               ▼
+       [setState(() => _isLoading = true)]  ← desabilita botões
+               │
+               ▼
+       [usuarioServiceProvider.update(
+           nomeCompleto, email, numeroCelular, dataNascimento,
+           onSuccess: ...,
+           onError: ...,
+       )]
+               │
+               ├─ onSuccess(usuario)
+               │       ├─ ref.invalidate(userProfileProvider)  ← atualiza P3-A
+               │       ├─ ScaffoldMessenger.showSnackBar('Perfil atualizado com sucesso ✓')
+               │       └─ context.pop()
+               │
+               └─ onError(message)
+                       ├─ ScaffoldMessenger.showSnackBar(message)
+                       └─ setState(() => _isLoading = false)
+```
+
+### Fluxo 3 — Trocar Senha
+
+```
+[Usuário preenche campos de senha e clica em "Salvar Alterações"]
+       │
+       ▼
+[_formKey.currentState!.validate()]
+       │  (campos de senha são validados junto ao Form)
+       │
+       └─ válido + _passwordController.text.isNotEmpty
+               │
+               ▼
+       [setState(() => _isLoadingPassword = true)]
+               │
+               ▼
+       [usuarioServiceProvider.changePassword(
+           senhaAtual, novaSenha, confirmarNovaSenha,
+           onSuccess: ...,
+           onError: ...,
+       )]
+               │
+               ├─ onSuccess()
+               │       ├─ _currentPasswordController.clear()
+               │       ├─ _passwordController.clear()
+               │       ├─ _confirmPasswordController.clear()
+               │       └─ ScaffoldMessenger.showSnackBar('Senha alterada com sucesso ✓')
+               │
+               └─ onError(message)
+                       └─ ScaffoldMessenger.showSnackBar(message)
+               │
+               └─ finally: setState(() => _isLoadingPassword = false)
+```
+
+> **Nota:** Os dois fluxos (dados pessoais + senha) podem ser executados na mesma submissão se ambos os grupos estiverem preenchidos. A ordem de execução é: **dados pessoais primeiro**, **senha depois** (se os campos estiverem preenchidos). Cada um tem seu snackbar e loading independente.
+
+---
+
+## Pseudocódigo de Implementação
+
+```dart
+// ANTES (mock):
+void initState() {
+  _nameController = TextEditingController(text: 'Acesse agora');  // ← remover
+  _emailController = TextEditingController(text: 'usuario@user.com'); // ← remover
+  ...
+}
+
+// DEPOIS (integração):
+void initState() {
+  super.initState();
+  final profile = ref.read(userProfileProvider).valueOrNull;
+  _nameController     = TextEditingController(text: profile?.nomeCompleto ?? '');
+  _emailController    = TextEditingController(text: profile?.email ?? '');
+  _phoneController    = TextEditingController(text: profile?.numeroCelular ?? '');
+  _birthdateController = TextEditingController(text: profile?.dataNascimento ?? '');
+  _currentPasswordController = TextEditingController();
+  _passwordController        = TextEditingController();
+  _confirmPasswordController = TextEditingController();
+}
+
+// ANTES (mock):
+Future<void> _savProfile() async {
+  await Future.delayed(const Duration(seconds: 1)); // ← remover
+}
+
+// DEPOIS (integração — dividido em dois):
+Future<void> _savePersonalData() async { ... }
+Future<void> _savePassword() async { ... }
+
+// Validator da senha atual — ANTES:
+if (_passwordController.text.isNotEmpty && value != '123456') { // ← remover
+  return 'Senha atual incorreta';
+}
+
+// DEPOIS: campo obrigatório se nova senha estiver preenchida (sem comparação local):
+if (_passwordController.text.isNotEmpty && (value?.isEmpty ?? true)) {
+  return 'Insira sua senha atual para alterar';
+}
+// Validação real é feita pelo backend via changePassword()
+```
+
+---
+
+## Dependências
+
+**Bibliotecas (já no projeto):**
+- [x] `flutter_riverpod` — `ConsumerStatefulWidget`, `ref.read`, `ref.invalidate`
+- [x] `dio` — cliente HTTP via `dioProvider` (usado internamente por `usuarioServiceProvider`)
+- [x] `go_router` — `context.pop()` já configurado no `app_router.dart`
+
+**Outras features:**
+- [x] **P3-A** (`user_profile_page`) — `userProfileProvider` deve estar carregado com dados reais antes de abrir esta tela; sem P3-A, os campos iniciam vazios (fallback seguro via `valueOrNull`)
+- [x] **P0** — `dio_client.dart` com interceptor Bearer token; o Dio já injeta o accessToken automaticamente em todas as requisições autenticadas
+
+---
+
+## Riscos Técnicos
+
+| Risco | Mitigação |
+|-------|-----------|
+| `ref.read(userProfileProvider)` retorna `AsyncLoading` no `initState` (P3-A ainda não carregou) | `valueOrNull` retorna `null` de forma segura; campos ficam vazios — comportamento aceitável (usuário pode preencher manualmente) |
+| Submit simultâneo de dados pessoais + senha causa race condition | Desabilitar ambos os botões enquanto qualquer operação estiver em andamento (`_isLoading \|\| _isLoadingPassword`); executar os dois calls de forma sequencial, não paralela |
+| `data_nascimento` chegando em formato `YYYY-MM-DD` do backend e sendo enviada como `DD/MM/AAAA` | `update()` já valida o formato `DD/MM/AAAA` — garantir que `_birthdateController` é pré-populado com o valor já convertido; se o backend retorna `YYYY-MM-DD`, converter no `initState` antes de popular o controller |
+| Trocar senha invalida refresh tokens; usuário pode ser deslogado de forma abrupta após a próxima expiração do access token | Documentar comportamento esperado; não tratar nesta task (escopo de auth — P2) |
+| Campo `numero_celular` vindo do backend sem formatação (apenas dígitos) e sendo exibido sem máscara | O `UsuarioService.update()` já remove a máscara antes de enviar; na exibição, o campo é apenas texto livre — aceitável para MVP; máscara pode ser adicionada via `input_formatters` em iteração futura |
+
+---
+
+## Referências
+
+- PRD: [`conductor/features/edit-user-profile-page.prd.md`](../features/edit-user-profile-page.prd.md)
+- Spec predecessor (P3-A): [`conductor/specs/user-profile-page.spec.md`](./user-profile-page.spec.md)
+- Arquivo alvo: `Frontend/lib/features/profile/presentation/pages/edit_user_profile_page.dart`
+- Service de rede: `Frontend/lib/utils/Usuario.dart` (métodos `update`, linhas 185–247; `changePassword`, linhas 254–294)
+- Provider: `Frontend/lib/features/profile/presentation/providers/user_profile_provider.dart`
+- Model: `Frontend/lib/features/profile/data/models/user_profile_model.dart`
+- API.md: seção 5 — Perfil do Hóspede (linhas 411–478)

--- a/conductor/specs/user-profile-page.spec.md
+++ b/conductor/specs/user-profile-page.spec.md
@@ -1,0 +1,163 @@
+# Spec — User Profile Page (P3-A)
+
+## Referência
+- **PRD:** `conductor/features/user-profile-page.prd.md`
+- **Arquivo principal:** `Frontend/lib/features/profile/presentation/pages/user_profile_page.dart`
+- **Branch:** `feat/user-profile-page-integration`
+
+---
+
+## Abordagem Técnica
+
+Converter `UserProfilePage` de `StatelessWidget` para `ConsumerWidget` (Riverpod), introduzindo:
+
+1. Um `UserProfileNotifier` (`AsyncNotifier<UserProfileModel>`) que dispara `GET /usuarios/me` automaticamente no primeiro `watch`
+2. Um `UserProfileModel` (DTO) para deserializar a resposta tipada, em vez de trabalhar com `Map<String, dynamic>` cru
+3. Reutilização de `usuarioServiceProvider` e seu método `getAutenticado()` já existente em `lib/utils/Usuario.dart` — sem duplicação de lógica de rede
+4. Tratamento declarativo dos três estados Riverpod (`AsyncLoading`, `AsyncData`, `AsyncError`) diretamente no `build()` da página
+
+O `ProfileHeader` já suporta `avatarUrl?` com fallback para ícone padrão — nenhuma alteração de widget é necessária para a foto de perfil.
+
+---
+
+## Componentes Afetados
+
+### Backend
+- Nenhum. O endpoint `GET /usuarios/me` já existe.
+
+### Frontend
+
+| Tipo | Arquivo | O que muda |
+|------|---------|-----------|
+| **Modificado** | `lib/features/profile/presentation/pages/user_profile_page.dart` | Converter para `ConsumerWidget`; substituir dados hardcoded por `UserProfileModel`; adicionar estados de loading e erro com retry |
+| **Novo** | `lib/features/profile/data/models/user_profile_model.dart` | DTO com `fromJson` para mapear a resposta de `/usuarios/me` |
+| **Novo** | `lib/features/profile/presentation/providers/user_profile_provider.dart` | `UserProfileNotifier` + `userProfileProvider` |
+
+---
+
+## Decisões de Arquitetura
+
+| Decisão | Justificativa |
+|---------|--------------|
+| `ConsumerWidget` em vez de `ConsumerStatefulWidget` | A página não tem estado local mutável (sem form, sem controllers); `ConsumerWidget` é mais simples e suficiente |
+| `AsyncNotifier<UserProfileModel>` para o notifier | Padrão já adotado no `AuthNotifier`; o `build()` async dispara o fetch automaticamente no primeiro `watch`, sem necessidade de `initState` |
+| Reutilizar `usuarioServiceProvider.getAutenticado()` | O método já existe, já trata erros via `_handleDioError` e já foi validado pelo time — criar outro service seria duplicação |
+| `UserProfileModel` com `fromJson` em vez de `Map<String, dynamic>` | Tipagem garante acesso seguro aos campos; facilita extensão para P3-C (edição) que precisará dos mesmos dados |
+| `ref.invalidate(userProfileProvider)` no botão "tentar novamente" | Força novo fetch sem criar lógica extra; padrão Riverpod para retry de `AsyncNotifier` |
+| Avatar sem nova dependência | `ProfileHeader` já usa `NetworkImage` com fallback para `Icons.person` quando `avatarUrl == null` — zero custo de pacote |
+
+---
+
+## Contratos de API
+
+| Método | Rota | Body | Response (2xx) |
+|--------|------|------|----------------|
+| GET | `/usuarios/me` | — | `{ data: { id, nome_completo, email, cpf, numero_celular, foto_perfil, data_nascimento } }` |
+
+### Erros esperados
+
+| Status | Significado | Comportamento |
+|--------|-------------|---------------|
+| 401 | Token expirado | Interceptor P0 faz refresh; se falhar, redireciona para `/auth/login` |
+| 5xx | Erro interno do servidor | `AsyncError` → exibe mensagem do `_handleDioError` + botão "Tentar novamente" |
+| timeout | Sem conexão | `AsyncError` → "Tempo de conexão esgotado. Verifique sua internet." + retry |
+
+---
+
+## Modelos de Dados
+
+```dart
+// lib/features/profile/data/models/user_profile_model.dart
+class UserProfileModel {
+  final String id;
+  final String nomeCompleto;
+  final String email;
+  final String? cpf;
+  final String? numeroCelular;
+  final String? fotoPerfil;
+  final String? dataNascimento;
+
+  const UserProfileModel({
+    required this.id,
+    required this.nomeCompleto,
+    required this.email,
+    this.cpf,
+    this.numeroCelular,
+    this.fotoPerfil,
+    this.dataNascimento,
+  });
+
+  factory UserProfileModel.fromJson(Map<String, dynamic> json) {
+    return UserProfileModel(
+      id: json['id'].toString(),
+      nomeCompleto: json['nome_completo'] as String,
+      email: json['email'] as String,
+      cpf: json['cpf'] as String?,
+      numeroCelular: json['numero_celular'] as String?,
+      fotoPerfil: json['foto_perfil'] as String?,
+      dataNascimento: json['data_nascimento'] as String?,
+    );
+  }
+}
+```
+
+---
+
+## Fluxo de Execução
+
+```
+[Usuário navega para /profile/user]
+       │
+       ▼
+[UserProfilePage.build() → ref.watch(userProfileProvider)]
+       │
+       ▼
+[UserProfileNotifier.build() → usuarioServiceProvider.getAutenticado()]
+       │
+       ├─ AsyncLoading
+       │       └─► Center(CircularProgressIndicator)
+       │
+       ├─ AsyncData(UserProfileModel)
+       │       └─► ProfileHeader(
+       │                 name: model.nomeCompleto,
+       │                 email: model.email,
+       │                 avatarUrl: model.fotoPerfil,   // null → ícone padrão
+       │                 onEditTap: () => context.push('/profile/user/edit'),
+       │             )
+       │           + ProfileMenuSection('Atividade') — sem mudança
+       │           + ProfileMenuSection('sistema')   — sem mudança
+       │           + PrimaryButton('sair')           — sem mudança
+       │
+       └─ AsyncError(message)
+               └─► Column(
+                     Text(message),
+                     ElevatedButton('Tentar novamente',
+                       onPressed: () => ref.invalidate(userProfileProvider),
+                     ),
+                   )
+```
+
+---
+
+## Dependências
+
+**Bibliotecas (já no projeto):**
+- [x] `flutter_riverpod` — `ConsumerWidget`, `AsyncNotifier`, `ref.watch`
+- [x] `dio` — cliente HTTP via `dioProvider` (usado internamente pelo `usuarioServiceProvider`)
+- [x] `go_router` — navegação para `/profile/user/edit` e `/profile/settings` já configurada no `app_router.dart`
+
+**Outras features:**
+- [x] P0 — `dio_client.dart` com interceptor de Bearer token e refresh automático de 401
+- [x] P2-A — `authProvider` armazena o token que o interceptor injeta no header
+- [x] `lib/utils/Usuario.dart` — `usuarioServiceProvider` com `getAutenticado()` já implementado
+
+---
+
+## Riscos Técnicos
+
+| Risco | Mitigação |
+|-------|-----------|
+| Campo `id` retornado como `int` pelo backend em vez de `String` | `json['id'].toString()` no `fromJson` garante conversão segura independente do tipo |
+| Campo `foto_perfil` retornando URL relativa (ex: `/uploads/foto.jpg`) | Verificar formato no primeiro teste de integração; se relativo, concatenar a base URL do `dioProvider` |
+| Dado de perfil stale após logout + re-login | `userProfileProvider` não usa `keepAlive`; Riverpod destrói o notifier quando o widget sai do tree — novo login reinicia um `build()` limpo |
+| Fetch disparado múltiplas vezes por rebuilds | `AsyncNotifier.build()` é chamado uma única vez por ciclo de vida do provider — Riverpod garante isso sem `initState` |


### PR DESCRIPTION
## O que foi feito

Integração da tela de edição de perfil do hóspede com o backend: faz a transição de dados mockados para chamadas reais utilizando `PATCH /usuarios/me` (dados pessoais) e `POST /usuarios/change-password` (segurança).
A implementação utiliza **Riverpod** para refletir as mudanças globalmente no app através da invalidação do `userProfileProvider` após o sucesso do update.

Introduz um **formatador de telefone dinâmico** customizado que alterna automaticamente entre os formatos fixo `(xx) xxxx-xxxx` e celular `(xx) xxxxx-xxxx`, atendendo rigorosamente à regra de hifonação brasileira exigida pelo backend.

> Plan: `conductor/plans/edit-user-profile-page.plan.md`

---

## Arquivos criados

| Arquivo | Descrição |
|--------|-----------|
| `conductor/features/edit-user-profile-page.prd.md` | PRD detalhando requisitos e critérios de aceitação |
| `conductor/specs/edit-user-profile-page.spec.md` | Spec técnica com contratos de API e fluxos de estado |
| `conductor/plans/edit-user-profile-page.plan.md` | Plan de execução atômico da feature |
| `P3-C-edit-user-profile-page.md` | Tracking da tarefa |

---

## Arquivos modificados

**`Frontend/lib/features/profile/presentation/pages/edit_user_profile_page.dart`**
- Convertida de `StatefulWidget` para `ConsumerStatefulWidget`.
- `initState` atualizado para pré-popular campos com dados reais do `userProfileProvider`.
- Adicionado parsing de data ISO (`YYYY-MM-DDTHH:mm:ss`) para formato nacional (`DD/MM/AAAA`).
- Implementado `_BrazilianPhoneFormatter` para suporte a 10 e 11 dígitos.
- Implementado fluxo de salvamento sequencial (Dados Pessoais -> Senha).
- Gestão de loading states independentes para dados e senha.

**`Frontend/lib/utils/Usuario.dart`**
- Atualizado `UsuarioService.update` e `register` para enviar o telefone com máscara, conforme exigência de validação da entidade no backend.

---

## Dependências desta PR

- **Requer:** P3-A (`userProfileProvider` ativo), P0 (Interceptor de Refresh Token), P2-A (Login funcional).
- **Consome:** `PATCH /usuarios/me` e `POST /usuarios/change-password`.

---

## Checklist de validação

- [x] Dado que o usuário está autenticado, ao abrir a edição de perfil, os campos Nome, Email, Telefone e Data de Nascimento são pré-populados com os dados reais do backend.
- [x] Dado que o usuário altera o Nome ou Email e clica em Salvar, a requisição `PATCH /usuarios/me` é realizada com sucesso e a tela anterior atualiza os dados automaticamente.
- [x] O campo de telefone aplica a máscara `(xx) xxxx-xxxx` por padrão e expande para `(xx) xxxxx-xxxx` ao digitar o 11º dígito.
- [x] A Data de Nascimento é convertida de formato ISO para `DD/MM/AAAA` na leitura e volta corretamente para o service.
- [x] Dado que o usuário preenche os campos de senha, a requisição `POST /usuarios/change-password` é disparada.
- [ ] Em caso de erro do backend (ex: email já em uso), um Snackbar exibe a mensagem de erro amigável sem fechar a tela.
- [x] Os botões de ação ficam desabilitados enquanto as requisições de rede estão em andamento.
