### PR TITLE
RES-18 ✨(feat): implement my_rooms_page integration with room management

### DIFF
--- a/Backend/database/scripts/init_tenant.sql
+++ b/Backend/database/scripts/init_tenant.sql
@@ -137,9 +137,10 @@ CREATE TABLE IF NOT EXISTS reserva (
     CONSTRAINT chk_status       CHECK (status IN ('SOLICITADA', 'AGUARDANDO_PAGAMENTO', 'APROVADA', 'CANCELADA', 'CONCLUIDA')),
     CONSTRAINT chk_canal        CHECK (canal_origem IN ('APP', 'WHATSAPP', 'BALCAO')),
 
-    -- Garante identificação mínima do hóspede
+    -- Identificação do hóspede opcional para walk-ins de balcão (bloqueio de agenda sem hóspede definido)
     CONSTRAINT chk_hospede_identificado CHECK (
-        user_id IS NOT NULL
+        canal_origem = 'BALCAO'
+        OR user_id IS NOT NULL
         OR (nome_hospede IS NOT NULL AND (cpf_hospede IS NOT NULL OR telefone_contato IS NOT NULL))
     ),
 

--- a/Backend/package.json
+++ b/Backend/package.json
@@ -13,6 +13,7 @@
     "db:seed": "ts-node --transpile-only src/database/seeds/index.ts",
     "db:seed:hotels": "ts-node --transpile-only src/database/seeds/seed.hotels.ts",
     "db:seed:recommended": "ts-node --transpile-only src/database/seeds/seed.recommendedRooms.ts",
+    "db:seed:my-rooms-page": "ts-node --transpile-only src/database/seeds/seed.my-rooms-page.ts",
     "test": "jest",
     "test:watch": "jest --watch",
     "test:coverage": "jest --coverage"

--- a/Backend/src/database/seeds/index.ts
+++ b/Backend/src/database/seeds/index.ts
@@ -37,6 +37,13 @@ const SEEDS: SeedEntry[] = [
       await seedRecommendedRooms();
     },
   },
+  {
+    name: 'myRoomsPage',
+    run: async () => {
+      const { seedMyRoomsPage } = await import('./seed.my-rooms-page');
+      await seedMyRoomsPage();
+    },
+  },
 ];
 // ──────────────────────────────────────────────────────────────────────────
 

--- a/Backend/src/database/seeds/seed.my-rooms-page.ts
+++ b/Backend/src/database/seeds/seed.my-rooms-page.ts
@@ -1,0 +1,285 @@
+/**
+ * Seed: my-rooms-page — Cenários de Teste
+ *
+ * Cria um hotel dedicado a testar a my_rooms_page com os seguintes cenários:
+ *
+ *  Cenário 1 — Dia totalmente lotado (Suíte Master — 3 unidades)
+ *    • Quartos 501, 502: APROVADA de HOJE+3 a HOJE+8
+ *    • Quarto 503:       APROVADA de HOJE+5 a HOJE+10
+ *    • Resultado: HOJE+5, HOJE+6, HOJE+7 têm 3/3 unidades → INDISPONÍVEL no calendário
+ *
+ *  Cenário 2 — Reserva manual até lotação (Quarto Duplo Premium — 2 unidades)
+ *    • Quarto 601: APROVADA de HOJE+1 a HOJE+4  (1/2 ocupado)
+ *    • Quarto 602: sem reserva
+ *    • Fazer reserva manual para 602 de HOJE+1 a HOJE+4 → dia vai para 2/2 → indisponível
+ *
+ *  Cenário 3 — Delete total (Quarto Single Business — 1 unidade)
+ *    • Quarto 701: sem reserva
+ *    • Deletar quantidade = 1 → categoria desaparece da listagem
+ *
+ *  Cenário 4 — Delete parcial (Suíte Família — 4 unidades)
+ *    • Quartos 801, 802, 803, 804: sem reserva
+ *    • Deletar quantidade = 2 → card permanece com 2 unidades
+ *
+ *  Cenário 5 — Busca por nome e filtro por categoria
+ *    • 4 categorias com nomes distintos: buscar "master", "duplo", "single", "família"
+ *
+ * Login do hotel:
+ *   email: myrooms@teste.com
+ *   senha: Seed@2026
+ */
+import 'dotenv/config';
+import { registerAnfitriao }                         from '../../services/anfitriao.service';
+import { updateConfiguracaoHotel }                   from '../../services/configuracao.service';
+import { createCatalogo }                            from '../../services/catalogo.service';
+import { createCategoriaQuarto, addItemToCategoria } from '../../services/categoriaQuarto.service';
+import { createQuarto }                              from '../../services/quarto.service';
+import { masterPool }                                from '../masterDb';
+import { withTenant }                                from '../schemaWrapper';
+import { CategoriaItem }                             from '../../entities/Catalogo';
+
+if (process.env.NODE_ENV === 'production') {
+  console.log('[seed/my-rooms-page] Seed ignorado em produção');
+  process.exit(0);
+}
+
+const HOTEL = {
+  nome_hotel:  'Hotel Teste MyRooms',
+  cnpj:        '99999999000199',
+  telefone:    '11911111199',
+  email:       'myrooms@teste.com',
+  senha:       'Seed@2026',
+  cep:         '01000000',
+  uf:          'SP',
+  cidade:      'São Paulo',
+  bairro:      'Centro',
+  rua:         'Rua dos Testes',
+  numero:      '1',
+  descricao:   'Hotel de testes criado exclusivamente para validação da my_rooms_page.',
+};
+
+const CATALOGO_ITENS: { nome: string; categoria: CategoriaItem }[] = [
+  { nome: 'Wi-Fi',              categoria: 'COMODIDADE' },
+  { nome: 'Ar-condicionado',    categoria: 'COMODIDADE' },
+  { nome: 'TV a cabo',          categoria: 'COMODIDADE' },
+  { nome: 'Frigobar',           categoria: 'COMODIDADE' },
+  { nome: 'Cama king-size',     categoria: 'COMODO'     },
+  { nome: 'Cama queen-size',    categoria: 'COMODO'     },
+  { nome: 'Cama de solteiro',   categoria: 'COMODO'     },
+  { nome: 'Banheiro privativo', categoria: 'COMODO'     },
+];
+
+function fmtDate(d: Date): string {
+  return d.toISOString().split('T')[0];
+}
+function addDays(d: Date, n: number): Date {
+  const r = new Date(d);
+  r.setDate(r.getDate() + n);
+  return r;
+}
+
+const TODAY = new Date();
+
+// Cenário 1 — Suíte Master (3 unidades) — dias lotados em HOJE+5, +6, +7
+const C1_A_IN  = fmtDate(addDays(TODAY,  3));  // 501+502 checkin
+const C1_A_OUT = fmtDate(addDays(TODAY,  8));  // 501+502 checkout (exclusivo)
+const C1_B_IN  = fmtDate(addDays(TODAY,  5));  // 503 checkin
+const C1_B_OUT = fmtDate(addDays(TODAY, 10));  // 503 checkout
+
+// Cenário 2 — Quarto Duplo Premium (2 unidades) — 601 ocupado, 602 livre para reserva manual
+const C2_IN  = fmtDate(addDays(TODAY, 1));
+const C2_OUT = fmtDate(addDays(TODAY, 4));
+
+export async function seedMyRoomsPage(): Promise<void> {
+  console.log('--- Seed: my-rooms-page ---\n');
+
+  try {
+    // ── 1. Criar hotel ──────────────────────────────────────────────────────
+    const hotel = await registerAnfitriao(HOTEL as any);
+    console.log(`  ✅ Hotel criado: ${hotel.nome_hotel} | schema: ${hotel.schema_name}`);
+
+    // ── 2. Configuração operacional ─────────────────────────────────────────
+    await updateConfiguracaoHotel(hotel.hotel_id, {
+      horario_checkin:       '14:00',
+      horario_checkout:      '12:00',
+      max_dias_reserva:      30,
+      politica_cancelamento: 'Cancelamento gratuito até 24h antes do check-in.',
+      aceita_animais:        false,
+      idiomas_atendimento:   'Português',
+    });
+
+    // ── 3. Catálogo de comodidades ──────────────────────────────────────────
+    const catalogoIds: Record<string, number> = {};
+    for (const item of CATALOGO_ITENS) {
+      const criado = await createCatalogo(hotel.hotel_id, { nome: item.nome, categoria: item.categoria });
+      catalogoIds[item.nome] = criado.id;
+    }
+    console.log(`  ✅ Catálogo: ${CATALOGO_ITENS.length} itens`);
+
+    // ── 4. Categorias + Quartos ─────────────────────────────────────────────
+
+    // [C1] Suíte Master — 3 unidades
+    const catSuite = await createCategoriaQuarto(hotel.hotel_id, {
+      nome: 'Suíte Master',
+      capacidade_pessoas: 2,
+      valor_diaria: 580,
+    });
+    for (const nome of ['Wi-Fi', 'Ar-condicionado', 'TV a cabo', 'Frigobar', 'Cama king-size', 'Banheiro privativo']) {
+      await addItemToCategoria(hotel.hotel_id, catSuite.id, { catalogo_id: catalogoIds[nome], quantidade: 1 });
+    }
+    await createQuarto(hotel.hotel_id, { categoria_quarto_id: catSuite.id, numero: '501', valor_diaria: 580, descricao: 'Suíte master com cama king-size e vista panorâmica.' });
+    await createQuarto(hotel.hotel_id, { categoria_quarto_id: catSuite.id, numero: '502', valor_diaria: 600, descricao: 'Suíte master premium no último andar.' });
+    await createQuarto(hotel.hotel_id, { categoria_quarto_id: catSuite.id, numero: '503', valor_diaria: 560, descricao: 'Suíte master com varanda e banheira.' });
+    console.log(`  ✅ Categoria "Suíte Master" | 3 quartos (501, 502, 503)`);
+
+    // [C2] Quarto Duplo Premium — 2 unidades
+    const catDuplo = await createCategoriaQuarto(hotel.hotel_id, {
+      nome: 'Quarto Duplo Premium',
+      capacidade_pessoas: 2,
+      valor_diaria: 320,
+    });
+    for (const nome of ['Wi-Fi', 'Ar-condicionado', 'TV a cabo', 'Cama queen-size', 'Banheiro privativo']) {
+      await addItemToCategoria(hotel.hotel_id, catDuplo.id, { catalogo_id: catalogoIds[nome], quantidade: 1 });
+    }
+    await createQuarto(hotel.hotel_id, { categoria_quarto_id: catDuplo.id, numero: '601', valor_diaria: 320, descricao: 'Quarto duplo renovado com cama queen-size.' });
+    await createQuarto(hotel.hotel_id, { categoria_quarto_id: catDuplo.id, numero: '602', valor_diaria: 340, descricao: 'Quarto duplo com varanda privativa.' });
+    console.log(`  ✅ Categoria "Quarto Duplo Premium" | 2 quartos (601, 602)`);
+
+    // [C3] Quarto Single Business — 1 unidade (para delete total)
+    const catSingle = await createCategoriaQuarto(hotel.hotel_id, {
+      nome: 'Quarto Single Business',
+      capacidade_pessoas: 1,
+      valor_diaria: 180,
+    });
+    for (const nome of ['Wi-Fi', 'Ar-condicionado', 'Cama de solteiro', 'Banheiro privativo']) {
+      await addItemToCategoria(hotel.hotel_id, catSingle.id, { catalogo_id: catalogoIds[nome], quantidade: 1 });
+    }
+    await createQuarto(hotel.hotel_id, { categoria_quarto_id: catSingle.id, numero: '701', valor_diaria: 180, descricao: 'Quarto individual compacto para viagens a trabalho.' });
+    console.log(`  ✅ Categoria "Quarto Single Business" | 1 quarto (701)`);
+
+    // [C4] Suíte Família — 4 unidades (para delete parcial)
+    const catFamilia = await createCategoriaQuarto(hotel.hotel_id, {
+      nome: 'Suíte Família',
+      capacidade_pessoas: 4,
+      valor_diaria: 420,
+    });
+    for (const nome of ['Wi-Fi', 'Ar-condicionado', 'TV a cabo', 'Frigobar', 'Cama queen-size', 'Banheiro privativo']) {
+      await addItemToCategoria(hotel.hotel_id, catFamilia.id, { catalogo_id: catalogoIds[nome], quantidade: 1 });
+    }
+    await createQuarto(hotel.hotel_id, { categoria_quarto_id: catFamilia.id, numero: '801', valor_diaria: 420, descricao: 'Suíte família com duas camas queen-size.' });
+    await createQuarto(hotel.hotel_id, { categoria_quarto_id: catFamilia.id, numero: '802', valor_diaria: 430, descricao: 'Suíte família com berço disponível sob pedido.' });
+    await createQuarto(hotel.hotel_id, { categoria_quarto_id: catFamilia.id, numero: '803', valor_diaria: 440, descricao: 'Suíte família com vista para o jardim.' });
+    await createQuarto(hotel.hotel_id, { categoria_quarto_id: catFamilia.id, numero: '804', valor_diaria: 450, descricao: 'Suíte família premium com banheira.' });
+    console.log(`  ✅ Categoria "Suíte Família" | 4 quartos (801–804)`);
+
+    // ── 5. Reservas para cenários 1 e 2 ────────────────────────────────────
+    await withTenant(hotel.schema_name, async (client) => {
+
+      // Obtém ou cria usuário de seed para vincular às reservas
+      let seedUserId: string;
+      const { rows: userRows } = await masterPool.query<{ user_id: string }>(
+        `INSERT INTO usuario (nome_completo, email, senha, cpf, numero_celular, data_nascimento)
+         VALUES ('Usuário Seed', 'seed@reservaqui.dev', '$2b$10$seedpasswordhashxxxxxseedpasswordhashxxxxxx',
+                 '000.000.000-00', '(00) 00000-0000', '1990-01-01')
+         ON CONFLICT (email) DO UPDATE SET nome_completo = EXCLUDED.nome_completo
+         RETURNING user_id`,
+      );
+      seedUserId = userRows[0].user_id;
+
+      // Registra como hóspede no tenant antes de criar reservas (FK obrigatória)
+      await client.query(
+        `INSERT INTO hospede (user_id) VALUES ($1) ON CONFLICT DO NOTHING`,
+        [seedUserId],
+      );
+
+      const { rows: quartoRows } = await client.query<{ id: number; numero: string }>(
+        `SELECT id, numero FROM quarto WHERE numero IN ('501','502','503','601') AND deleted_at IS NULL`,
+      );
+      const byNumero = Object.fromEntries(quartoRows.map((r) => [r.numero, r.id]));
+
+      const insertReserva = async (
+        quartoId: number,
+        checkin: string,
+        checkout: string,
+        valor: number,
+      ) => {
+        await client.query(
+          `INSERT INTO reserva
+             (quarto_id, user_id, num_hospedes, data_checkin, data_checkout,
+              status, canal_origem, valor_total, codigo_publico)
+           VALUES ($1, $2, 1, $3, $4, 'APROVADA', 'APP', $5, gen_random_uuid())`,
+          [quartoId, seedUserId, checkin, checkout, valor],
+        );
+      };
+
+      // Cenário 1 — Suíte Master: 501+502 de C1_A, 503 de C1_B → lotação em HOJE+5..+7
+      if (byNumero['501']) await insertReserva(byNumero['501'], C1_A_IN, C1_A_OUT, 580 * 5);
+      if (byNumero['502']) await insertReserva(byNumero['502'], C1_A_IN, C1_A_OUT, 600 * 5);
+      if (byNumero['503']) await insertReserva(byNumero['503'], C1_B_IN, C1_B_OUT, 560 * 5);
+      console.log(`  ✅ Reservas C1 (Suíte Master): 501+502 de ${C1_A_IN}→${C1_A_OUT} | 503 de ${C1_B_IN}→${C1_B_OUT}`);
+
+      // Cenário 2 — Duplo Premium: 601 ocupado; 602 livre para reserva manual
+      if (byNumero['601']) await insertReserva(byNumero['601'], C2_IN, C2_OUT, 320 * 3);
+      console.log(`  ✅ Reserva C2 (Duplo Premium): 601 de ${C2_IN}→${C2_OUT} (602 livre para reserva manual)`);
+    });
+
+    console.log(`
+╔══════════════════════════════════════════════════════════════════╗
+║          SEED my-rooms-page concluído com sucesso                ║
+╠══════════════════════════════════════════════════════════════════╣
+║  Login: myrooms@teste.com                                        ║
+║  Senha: Seed@2026                                                ║
+╠══════════════════════════════════════════════════════════════════╣
+║  CENÁRIOS DE TESTE                                               ║
+║                                                                  ║
+║  [C1] Suíte Master — 3 unidades                                  ║
+║    • Abrir reserva manual → HOJE+5, +6, +7 = BLOQUEADOS          ║
+║    • HOJE+3, +4 = parcial (2/3); a partir de HOJE+8 = 1/3       ║
+║                                                                  ║
+║  [C2] Quarto Duplo Premium — 2 unidades                          ║
+║    • 601 APROVADA ${C2_IN} → ${C2_OUT}              ║
+║    • Fazer reserva manual 602 no mesmo período                   ║
+║      → dias HOJE+1, +2, +3 ficam BLOQUEADOS (2/2)               ║
+║                                                                  ║
+║  [C3] Quarto Single Business — 1 unidade                         ║
+║    • Deletar quantidade = 1 → categoria some da listagem         ║
+║                                                                  ║
+║  [C4] Suíte Família — 4 unidades                                 ║
+║    • Deletar quantidade = 2 → card fica com 2 unidades           ║
+║                                                                  ║
+║  [C5] Busca por nome:                                            ║
+║    • "master"  → Suíte Master                                    ║
+║    • "duplo"   → Quarto Duplo Premium                            ║
+║    • "single"  → Quarto Single Business                          ║
+║    • "família" → Suíte Família                                   ║
+║                                                                  ║
+║  [C5] Filtro por categoria: clicar cada chip                     ║
+║    → apenas aquela categoria é exibida                           ║
+╚══════════════════════════════════════════════════════════════════╝
+`);
+
+  } catch (err: any) {
+    if (
+      err.message?.includes('duplicate key') ||
+      err.message?.includes('unique constraint') ||
+      err.message?.includes('ja existe')
+    ) {
+      console.log(`  ⚠️  Hotel "Hotel Teste MyRooms" já existe (rode db:reset para recriar)`);
+    } else {
+      throw err;
+    }
+  }
+}
+
+// Auto-execução quando rodado diretamente
+if (require.main === module) {
+  seedMyRoomsPage()
+    .catch((err) => {
+      console.error('[seed/my-rooms-page] Erro fatal:', err);
+      process.exit(1);
+    })
+    .finally(async () => {
+      await masterPool.end();
+      process.exit(0);
+    });
+}

--- a/Backend/src/entities/Reserva.ts
+++ b/Backend/src/entities/Reserva.ts
@@ -24,9 +24,9 @@ export interface CreateReservaUsuarioInput {
   p_turisticos?: unknown;
 }
 
-/** Criação de reserva walk-in pelo hotel (balcão). */
+/** Criação de reserva walk-in pelo hotel (balcão ou bloqueio de agenda). */
 export interface CreateReservaWalkinInput {
-  // Identificação do hóspede — user registrado OU dados manuais
+  // Identificação do hóspede — opcional para bloqueios de agenda sem hóspede definido
   user_id?:          string;
   nome_hospede?:     string;
   cpf_hospede?:      string;
@@ -167,26 +167,27 @@ export class Reserva {
     return result;
   }
 
-  /** Valida criação de reserva walk-in pelo hotel (BALCAO). */
+  /** Valida criação de reserva walk-in pelo hotel (balcão ou bloqueio de agenda). */
   static validateWalkin(input: unknown): CreateReservaWalkinInput {
     const data = input as Record<string, unknown>;
 
-    const num_hospedes   = this.validateNumHospedes(data.num_hospedes);
-    const data_checkin   = this.validateDate(data.data_checkin, 'data_checkin');
-    const data_checkout  = this.validateDate(data.data_checkout, 'data_checkout');
-    const valor_total    = this.validateValorTotal(data.valor_total);
+    const num_hospedes  = this.validateNumHospedes(data.num_hospedes);
+    const data_checkin  = this.validateDate(data.data_checkin, 'data_checkin');
+    const data_checkout = this.validateDate(data.data_checkout, 'data_checkout');
+    const valor_total   = this.validateValorTotal(data.valor_total);
 
     if (data_checkout <= data_checkin)
       throw new Error('data_checkout deve ser posterior à data_checkin');
 
-    // Identificação do hóspede: user_id registrado OU nome + (cpf ou telefone)
-    const hasUserId     = data.user_id !== undefined && data.user_id !== null && data.user_id !== '';
-    const hasNome       = typeof data.nome_hospede === 'string' && data.nome_hospede.trim().length > 0;
-    const hasCpfOrFone  = (typeof data.cpf_hospede === 'string' && data.cpf_hospede.trim().length > 0)
-                       || (typeof data.telefone_contato === 'string' && data.telefone_contato.trim().length > 0);
+    // Identificação do hóspede é opcional — reservas de balcão podem bloquear agenda sem hóspede
+    const hasUserId    = data.user_id !== undefined && data.user_id !== null && data.user_id !== '';
+    const hasNome      = typeof data.nome_hospede === 'string' && data.nome_hospede.trim().length > 0;
+    const hasCpfOrFone = (typeof data.cpf_hospede === 'string' && data.cpf_hospede.trim().length > 0)
+                      || (typeof data.telefone_contato === 'string' && data.telefone_contato.trim().length > 0);
 
-    if (!hasUserId && !(hasNome && hasCpfOrFone))
-      throw new Error('Identifique o hóspede: informe user_id ou nome_hospede + (cpf_hospede ou telefone_contato)');
+    // Se informou nome, exige cpf ou telefone para consistência
+    if (hasNome && !hasCpfOrFone)
+      throw new Error('Ao informar nome do hóspede, forneça também cpf_hospede ou telefone_contato');
 
     // Quarto: id físico OU texto livre
     if (data.quarto_id === undefined && !data.tipo_quarto)
@@ -197,20 +198,20 @@ export class Reserva {
 
     const result: CreateReservaWalkinInput = { num_hospedes, data_checkin, data_checkout };
 
-    if (data.valor_total !== undefined)    result.valor_total      = valor_total;
-    if (hasUserId)                        result.user_id          = this.validateUserId(data.user_id);
-    if (hasNome)                          result.nome_hospede     = (data.nome_hospede as string).trim();
+    if (data.valor_total !== undefined) result.valor_total = valor_total;
+    if (hasUserId) result.user_id = this.validateUserId(data.user_id);
+    if (hasNome)   result.nome_hospede = (data.nome_hospede as string).trim();
     if (typeof data.cpf_hospede === 'string' && data.cpf_hospede.trim())
-                                          result.cpf_hospede      = data.cpf_hospede.trim();
+      result.cpf_hospede = data.cpf_hospede.trim();
     if (typeof data.telefone_contato === 'string' && data.telefone_contato.trim())
-                                          result.telefone_contato = data.telefone_contato.trim();
-    if (data.quarto_id  !== undefined)    result.quarto_id        = this.validateQuartoId(data.quarto_id);
+      result.telefone_contato = data.telefone_contato.trim();
+    if (data.quarto_id !== undefined) result.quarto_id = this.validateQuartoId(data.quarto_id);
     if (data.tipo_quarto !== undefined) {
       if (typeof data.tipo_quarto !== 'string' || !data.tipo_quarto.trim())
         throw new Error('tipo_quarto inválido');
       result.tipo_quarto = data.tipo_quarto.trim();
     }
-    if (data.observacoes !== undefined)   result.observacoes      = this.validateObservacoes(data.observacoes);
+    if (data.observacoes !== undefined) result.observacoes = this.validateObservacoes(data.observacoes);
     if (typeof data.sessao_chat_id === 'string') result.sessao_chat_id = data.sessao_chat_id;
 
     return result;

--- a/Frontend/lib/features/rooms/domain/models/quarto.dart
+++ b/Frontend/lib/features/rooms/domain/models/quarto.dart
@@ -1,0 +1,65 @@
+class QuartoItemModel {
+  final int catalogoId;
+  final String nome;
+  final String categoria;
+  final int quantidade;
+
+  const QuartoItemModel({
+    required this.catalogoId,
+    required this.nome,
+    required this.categoria,
+    required this.quantidade,
+  });
+
+  factory QuartoItemModel.fromJson(Map<String, dynamic> json) {
+    return QuartoItemModel(
+      catalogoId: json['catalogo_id'] as int? ?? 0,
+      nome: json['nome'] as String? ?? '',
+      categoria: json['categoria'] as String? ?? '',
+      quantidade: json['quantidade'] as int? ?? 1,
+    );
+  }
+}
+
+class QuartoModel {
+  final int id;
+  final String numero;
+  final int categoriaQuartoId;
+  final bool disponivel;
+  final String? descricao;
+  final double? valorDiaria;
+  final List<QuartoItemModel> itens;
+
+  const QuartoModel({
+    required this.id,
+    required this.numero,
+    required this.categoriaQuartoId,
+    required this.disponivel,
+    this.descricao,
+    this.valorDiaria,
+    this.itens = const [],
+  });
+
+  factory QuartoModel.fromJson(Map<String, dynamic> json) {
+    final itensRaw = json['itens'] as List<dynamic>? ?? [];
+    return QuartoModel(
+      id: json['id'] as int? ?? 0,
+      numero: json['numero'] as String? ?? '',
+      categoriaQuartoId: json['categoria_quarto_id'] as int? ?? 0,
+      disponivel: json['disponivel'] as bool? ?? true,
+      descricao: json['descricao'] as String?,
+      valorDiaria: _parseDouble(json['valor_diaria']),
+      itens: itensRaw
+          .map((i) => QuartoItemModel.fromJson(i as Map<String, dynamic>))
+          .toList(),
+    );
+  }
+
+  static double? _parseDouble(dynamic value) {
+    if (value == null) return null;
+    if (value is double) return value;
+    if (value is int) return value.toDouble();
+    if (value is String) return double.tryParse(value);
+    return null;
+  }
+}

--- a/Frontend/lib/features/rooms/domain/models/reserva_hotel.dart
+++ b/Frontend/lib/features/rooms/domain/models/reserva_hotel.dart
@@ -1,0 +1,33 @@
+// Status que contabilizam ocupação de unidades — CANCELADA e CONCLUIDA não bloqueiam vagas
+const kStatusAtivos = {'SOLICITADA', 'AGUARDANDO_PAGAMENTO', 'APROVADA'};
+
+class ReservaHotelModel {
+  final int id;
+  final int? quartoId;
+  final String? tipoQuarto;
+  final DateTime dataCheckin;
+  final DateTime dataCheckout;
+  final String status;
+
+  const ReservaHotelModel({
+    required this.id,
+    this.quartoId,
+    this.tipoQuarto,
+    required this.dataCheckin,
+    required this.dataCheckout,
+    required this.status,
+  });
+
+  bool get ativa => kStatusAtivos.contains(status);
+
+  factory ReservaHotelModel.fromJson(Map<String, dynamic> json) {
+    return ReservaHotelModel(
+      id: json['id'] as int? ?? 0,
+      quartoId: json['quarto_id'] as int?,
+      tipoQuarto: json['tipo_quarto'] as String?,
+      dataCheckin: DateTime.parse(json['data_checkin'] as String),
+      dataCheckout: DateTime.parse(json['data_checkout'] as String),
+      status: json['status'] as String? ?? '',
+    );
+  }
+}

--- a/Frontend/lib/features/rooms/domain/models/room_category_card.dart
+++ b/Frontend/lib/features/rooms/domain/models/room_category_card.dart
@@ -1,0 +1,43 @@
+class RoomCategoryCardModel {
+  final int categoriaId;
+  final String nomeCategoria;
+  final String? descricao;
+  final int totalUnidades;
+  final List<int> quartoIds;
+  final String? fotoUrl;
+  final double? valorBase;
+  final bool disponivel;
+  // Preenchida apenas em cards inativos — próxima reserva ativa associada a essa categoria
+  final DateTime? proximaReservaAtiva;
+
+  const RoomCategoryCardModel({
+    required this.categoriaId,
+    required this.nomeCategoria,
+    this.descricao,
+    required this.totalUnidades,
+    required this.quartoIds,
+    this.fotoUrl,
+    this.valorBase,
+    this.disponivel = true,
+    this.proximaReservaAtiva,
+  });
+
+  RoomCategoryCardModel copyWith({
+    String? fotoUrl,
+    double? valorBase,
+    String? descricao,
+    DateTime? proximaReservaAtiva,
+  }) {
+    return RoomCategoryCardModel(
+      categoriaId: categoriaId,
+      nomeCategoria: nomeCategoria,
+      descricao: descricao ?? this.descricao,
+      totalUnidades: totalUnidades,
+      quartoIds: quartoIds,
+      fotoUrl: fotoUrl ?? this.fotoUrl,
+      valorBase: valorBase ?? this.valorBase,
+      disponivel: disponivel,
+      proximaReservaAtiva: proximaReservaAtiva ?? this.proximaReservaAtiva,
+    );
+  }
+}

--- a/Frontend/lib/features/rooms/domain/services/availability_calculator.dart
+++ b/Frontend/lib/features/rooms/domain/services/availability_calculator.dart
@@ -1,0 +1,60 @@
+import '../models/reserva_hotel.dart';
+
+// Retorna o conjunto de dias indisponíveis para uma categoria com [totalUnidades] unidades.
+// Um dia D é indisponível quando o número de reservas ativas que cobrem D é >= totalUnidades.
+// Convenção: checkin inclusivo, checkout exclusivo (o dia do checkout ainda tem vaga).
+//
+// Conta dois tipos de reserva:
+//   1. Reservas com quarto_id físico (ex: reservas via app)
+//   2. Walk-ins BALCAO com tipo_quarto textual — sem quarto_id atribuído
+Set<DateTime> computeDiasIndisponiveis(
+  List<ReservaHotelModel> todasReservas,
+  List<int> quartoIds,
+  int totalUnidades, {
+  String? nomeCategoria,
+}) {
+  if (totalUnidades <= 0 || quartoIds.isEmpty) return {};
+
+  final nomeNorm = nomeCategoria?.toLowerCase().trim();
+
+  final reservasDaCategoria = todasReservas.where((r) {
+    if (!r.ativa) return false;
+    // Reserva com quarto físico pertencente a esta categoria
+    if (r.quartoId != null && quartoIds.contains(r.quartoId)) return true;
+    // Walk-in BALCAO sem quarto atribuído — identifica pela categoria textual
+    if (r.quartoId == null && nomeNorm != null && r.tipoQuarto != null) {
+      return r.tipoQuarto!.toLowerCase().trim() == nomeNorm;
+    }
+    return false;
+  }).toList();
+
+  if (reservasDaCategoria.isEmpty) return {};
+
+  // Janela de datas a avaliar: do checkin mais cedo ao checkout mais tarde
+  final minDate = reservasDaCategoria
+      .map((r) => r.dataCheckin)
+      .reduce((a, b) => a.isBefore(b) ? a : b);
+  final maxDate = reservasDaCategoria
+      .map((r) => r.dataCheckout)
+      .reduce((a, b) => a.isAfter(b) ? a : b);
+
+  final indisponiveis = <DateTime>{};
+  var dia = DateTime(minDate.year, minDate.month, minDate.day);
+  final fim = DateTime(maxDate.year, maxDate.month, maxDate.day);
+
+  while (!dia.isAfter(fim)) {
+    final ocupacao = reservasDaCategoria.where((r) {
+      final checkin  = DateTime(r.dataCheckin.year, r.dataCheckin.month, r.dataCheckin.day);
+      final checkout = DateTime(r.dataCheckout.year, r.dataCheckout.month, r.dataCheckout.day);
+      return !dia.isBefore(checkin) && dia.isBefore(checkout);
+    }).length;
+
+    if (ocupacao >= totalUnidades) {
+      indisponiveis.add(dia);
+    }
+
+    dia = dia.add(const Duration(days: 1));
+  }
+
+  return indisponiveis;
+}

--- a/Frontend/lib/features/rooms/presentation/notifiers/my_rooms_notifier.dart
+++ b/Frontend/lib/features/rooms/presentation/notifiers/my_rooms_notifier.dart
@@ -1,0 +1,471 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import '../../../../core/network/dio_client.dart';
+import '../../domain/models/quarto.dart';
+import '../../domain/models/room_category_card.dart';
+import '../../domain/models/reserva_hotel.dart';
+import '../../domain/models/hotel_details.dart';
+import '../../domain/services/availability_calculator.dart';
+import 'my_rooms_state.dart';
+
+class MyRoomsNotifier extends Notifier<MyRoomsState> {
+  @override
+  MyRoomsState build() => const MyRoomsState();
+
+  Future<void> load() async {
+    state = state.copyWith(loading: true, clearError: true);
+
+    try {
+      final dio = ref.read(dioProvider);
+
+      final hotelId = await _fetchHotelId(dio);
+      if (hotelId == null) {
+        state = state.copyWith(
+            loading: false, error: 'Sessão expirada. Faça login novamente.');
+        return;
+      }
+
+      final now = DateTime.now();
+      final from = _fmtDate(now);
+      final to = _fmtDate(now.add(const Duration(days: 180)));
+
+      final results = await Future.wait(
+        [
+          _loadQuartos(dio),
+          _loadCategorias(dio, hotelId),
+          _loadReservas(dio, from, to),
+        ],
+        eagerError: false,
+      );
+
+      final quartos    = results[0] as List<QuartoModel>;
+      final categorias = results[1] as List<CategoriaHotelModel>;
+      final reservas   = results[2] as List<ReservaHotelModel>;
+
+      final cards = _buildCards(quartos, categorias, reservas);
+      final cardsComFoto = await _loadFotos(dio, hotelId, cards);
+      final disponibilidade = _calcularDisponibilidade(cardsComFoto, reservas);
+
+      state = state.copyWith(
+        cards: cardsComFoto,
+        categorias: categorias,
+        reservas: reservas,
+        diasIndisponiveisPorCategoria: disponibilidade,
+        loading: false,
+      );
+    } catch (e, st) {
+      debugPrint('[myRoomsNotifier] Erro ao carregar: $e\n$st');
+      state = state.copyWith(
+          loading: false,
+          error: 'Não foi possível carregar os quartos. Verifique sua conexão e tente novamente.');
+    }
+  }
+
+  Future<void> refresh() => load();
+
+  void setBusca(String busca) => state = state.copyWith(busca: busca);
+
+  void setFiltro(FiltroDisponibilidade filtro) =>
+      state = state.copyWith(filtroDisponibilidade: filtro);
+
+  // ── Deactivate (Desativar) ────────────────────────────────────────────────
+
+  // Retorna {'sucesso': N, 'falha': N}
+  Future<Map<String, int>> deativarUnidades(
+    int categoriaId,
+    int quantidade, {
+    required bool permanente,
+  }) async {
+    final card = state.cards.firstWhere(
+        (c) => c.categoriaId == categoriaId && c.disponivel);
+    final idsParaDesativar = card.quartoIds.take(quantidade).toList();
+
+    state = state.copyWith(deleteInProgress: true);
+
+    final dio = ref.read(dioProvider);
+    int sucesso = 0, falha = 0;
+    final now = DateTime.now();
+
+    for (final quartoId in idsParaDesativar) {
+      if (permanente) {
+        final temReserva = state.reservas.any((r) =>
+            r.ativa &&
+            r.quartoId == quartoId &&
+            r.dataCheckout.isAfter(now));
+
+        if (temReserva) {
+          // Não pode deletar — marca como indisponível
+          final ok = await _patchDisponivel(dio, quartoId, false);
+          if (ok) sucesso++; else falha++;
+        } else {
+          final ok = await _deleteQuarto(dio, quartoId);
+          if (ok) sucesso++; else falha++;
+        }
+      } else {
+        final ok = await _patchDisponivel(dio, quartoId, false);
+        if (ok) sucesso++; else falha++;
+      }
+    }
+
+    await load();
+    state = state.copyWith(deleteInProgress: false);
+    return {'sucesso': sucesso, 'falha': falha};
+  }
+
+  // ── Reactivate (Reativar) ─────────────────────────────────────────────────
+
+  Future<Map<String, int>> reativarUnidades(int categoriaId) async {
+    final card = state.cards.firstWhere(
+        (c) => c.categoriaId == categoriaId && !c.disponivel);
+
+    state = state.copyWith(deleteInProgress: true);
+
+    final dio = ref.read(dioProvider);
+    int sucesso = 0, falha = 0;
+
+    for (final quartoId in card.quartoIds) {
+      final ok = await _patchDisponivel(dio, quartoId, true);
+      if (ok) sucesso++; else falha++;
+    }
+
+    await load();
+    state = state.copyWith(deleteInProgress: false);
+    return {'sucesso': sucesso, 'falha': falha};
+  }
+
+  // ── Delete from inactive card (Remover do card inativo) ───────────────────
+
+  // Retorna null se a exclusão é permitida, ou mensagem de bloqueio.
+  // Bloqueio: reservas ativas para os quartos inativos > quartos ativos da mesma categoria.
+  String? verificarBloqueioExclusao(int categoriaId) {
+    final inativoCard = state.cards.firstWhere(
+        (c) => c.categoriaId == categoriaId && !c.disponivel);
+
+    final now = DateTime.now();
+    final reservasAtivas = state.reservas
+        .where((r) =>
+            r.ativa &&
+            r.quartoId != null &&
+            inativoCard.quartoIds.contains(r.quartoId) &&
+            r.dataCheckout.isAfter(now))
+        .length;
+
+    if (reservasAtivas == 0) return null;
+
+    final ativoCard = state.cards
+        .where((c) => c.categoriaId == categoriaId && c.disponivel)
+        .firstOrNull;
+    final quartosAtivos = ativoCard?.totalUnidades ?? 0;
+
+    if (reservasAtivas > quartosAtivos) {
+      return 'Este quarto possui $reservasAtivas reserva${reservasAtivas != 1 ? 's' : ''} ativa${reservasAtivas != 1 ? 's' : ''} e a categoria conta com apenas $quartosAtivos quarto${quartosAtivos != 1 ? 's' : ''} ativo${quartosAtivos != 1 ? 's' : ''}. Aguarde a conclusão das reservas antes de excluir.';
+    }
+
+    return null;
+  }
+
+  Future<Map<String, int>> excluirUnidadesInativas(int categoriaId) async {
+    final card = state.cards.firstWhere(
+        (c) => c.categoriaId == categoriaId && !c.disponivel);
+
+    state = state.copyWith(deleteInProgress: true);
+
+    final dio = ref.read(dioProvider);
+    int sucesso = 0, falha = 0;
+
+    for (final quartoId in card.quartoIds) {
+      final ok = await _deleteQuarto(dio, quartoId);
+      if (ok) sucesso++; else falha++;
+    }
+
+    await load();
+    state = state.copyWith(deleteInProgress: false);
+    return {'sucesso': sucesso, 'falha': falha};
+  }
+
+  // ── Manual reservation ────────────────────────────────────────────────────
+
+  Future<String?> criarReservaManual({
+    required int categoriaId,
+    required DateTime checkin,
+    required DateTime checkout,
+    required double valorTotal,
+  }) async {
+    final card = state.cards.firstWhere(
+        (c) => c.categoriaId == categoriaId && c.disponivel);
+    state = state.copyWith(reservaInProgress: true);
+
+    try {
+      final dio = ref.read(dioProvider);
+
+      await dio.post<Map<String, dynamic>>(
+        '/hotel/reservas',
+        data: {
+          'canal_origem': 'BALCAO',
+          'tipo_quarto': card.nomeCategoria,
+          'num_hospedes': 1,
+          'data_checkin': _fmtDate(checkin),
+          'data_checkout': _fmtDate(checkout),
+          'valor_total': valorTotal,
+        },
+      );
+
+      await load();
+      state = state.copyWith(reservaInProgress: false);
+      return null;
+    } catch (e) {
+      debugPrint('[myRoomsNotifier] Erro ao criar reserva manual: $e');
+      state = state.copyWith(reservaInProgress: false);
+      return 'Não foi possível criar a reserva. Tente novamente ou entre em contato com o suporte.';
+    }
+  }
+
+  // ── Helpers: active reservation check ────────────────────────────────────
+
+  bool temReservaAtiva(List<int> quartoIds) {
+    final now = DateTime.now();
+    return state.reservas.any((r) =>
+        r.ativa &&
+        r.quartoId != null &&
+        quartoIds.contains(r.quartoId) &&
+        r.dataCheckout.isAfter(now));
+  }
+
+  DateTime? proximaReservaAtiva(List<int> quartoIds) {
+    final now = DateTime.now();
+    final ativas = state.reservas
+        .where((r) =>
+            r.ativa &&
+            r.quartoId != null &&
+            quartoIds.contains(r.quartoId) &&
+            r.dataCheckout.isAfter(now))
+        .toList();
+    if (ativas.isEmpty) return null;
+    return ativas
+        .map((r) => r.dataCheckin)
+        .reduce((a, b) => a.isBefore(b) ? a : b);
+  }
+
+  // ── Privados ──────────────────────────────────────────────────────────────
+
+  Future<String?> _fetchHotelId(dynamic dio) async {
+    try {
+      final response = await dio.get<Map<String, dynamic>>('/hotel/me');
+      final data = response.data?['data'] as Map<String, dynamic>?;
+      final id = data?['hotel_id'] ?? data?['id'];
+      return id?.toString();
+    } catch (e) {
+      debugPrint('[myRoomsNotifier] Erro ao buscar hotel_id: $e');
+      return null;
+    }
+  }
+
+  Future<List<QuartoModel>> _loadQuartos(dynamic dio) async {
+    try {
+      final response = await dio.get<Map<String, dynamic>>('/hotel/quartos');
+      final items = (response.data?['data'] as List<dynamic>?) ?? [];
+      return items
+          .map((i) => QuartoModel.fromJson(i as Map<String, dynamic>))
+          .toList();
+    } catch (e) {
+      debugPrint('[myRoomsNotifier] Erro ao carregar quartos: $e');
+      rethrow;
+    }
+  }
+
+  Future<List<CategoriaHotelModel>> _loadCategorias(
+      dynamic dio, String hotelId) async {
+    try {
+      final response =
+          await dio.get<Map<String, dynamic>>('/hotel/$hotelId/categorias');
+      final items = (response.data?['data'] as List<dynamic>?) ?? [];
+      return items
+          .map((i) => CategoriaHotelModel.fromJson(i as Map<String, dynamic>))
+          .toList();
+    } catch (e) {
+      debugPrint('[myRoomsNotifier] Erro ao carregar categorias: $e');
+      return [];
+    }
+  }
+
+  Future<List<ReservaHotelModel>> _loadReservas(
+      dynamic dio, String from, String to) async {
+    try {
+      final response = await dio.get<Map<String, dynamic>>(
+        '/hotel/reservas',
+        queryParameters: {'data_checkin_from': from, 'data_checkout_to': to},
+      );
+      final items = (response.data?['data'] as List<dynamic>?) ?? [];
+      return items
+          .map((i) => ReservaHotelModel.fromJson(i as Map<String, dynamic>))
+          .toList();
+    } catch (e) {
+      debugPrint('[myRoomsNotifier] Reservas indisponíveis (não fatal): $e');
+      return [];
+    }
+  }
+
+  // Cria um card por grupo (categoriaId + disponivel).
+  // Cards ativos usam apenas quartos disponíveis; inativos usam os indisponíveis.
+  List<RoomCategoryCardModel> _buildCards(
+    List<QuartoModel> quartos,
+    List<CategoriaHotelModel> categorias,
+    List<ReservaHotelModel> reservas,
+  ) {
+    final categoriaMap = {for (final c in categorias) c.id: c};
+    final gruposAtivos   = <int, List<QuartoModel>>{};
+    final gruposInativos = <int, List<QuartoModel>>{};
+
+    for (final q in quartos) {
+      if (q.disponivel) {
+        gruposAtivos.putIfAbsent(q.categoriaQuartoId, () => []).add(q);
+      } else {
+        gruposInativos.putIfAbsent(q.categoriaQuartoId, () => []).add(q);
+      }
+    }
+
+    final cards = <RoomCategoryCardModel>[];
+    final now = DateTime.now();
+
+    for (final entry in gruposAtivos.entries) {
+      cards.add(_makeCard(entry.key, entry.value, categoriaMap[entry.key],
+          disponivel: true));
+    }
+
+    for (final entry in gruposInativos.entries) {
+      final quartoIds = entry.value.map((q) => q.id).toList();
+
+      // Próxima reserva ativa para exibição no card inativo
+      final ativas = reservas
+          .where((r) =>
+              r.ativa &&
+              r.quartoId != null &&
+              quartoIds.contains(r.quartoId) &&
+              r.dataCheckout.isAfter(now))
+          .toList();
+      final proxima = ativas.isNotEmpty
+          ? ativas
+              .map((r) => r.dataCheckin)
+              .reduce((a, b) => a.isBefore(b) ? a : b)
+          : null;
+
+      cards.add(_makeCard(
+        entry.key,
+        entry.value,
+        categoriaMap[entry.key],
+        disponivel: false,
+        proximaReservaAtiva: proxima,
+      ));
+    }
+
+    return cards;
+  }
+
+  RoomCategoryCardModel _makeCard(
+    int catId,
+    List<QuartoModel> unidades,
+    CategoriaHotelModel? cat, {
+    required bool disponivel,
+    DateTime? proximaReservaAtiva,
+  }) {
+    final valorBase = unidades
+        .where((q) => q.valorDiaria != null)
+        .map((q) => q.valorDiaria!)
+        .fold<double?>(null, (prev, v) => prev == null ? v : (prev + v) / 2);
+
+    return RoomCategoryCardModel(
+      categoriaId: catId,
+      nomeCategoria: cat?.nome ?? 'Categoria $catId',
+      descricao: unidades
+          .firstWhere((q) => q.descricao != null,
+              orElse: () => unidades.first)
+          .descricao,
+      totalUnidades: unidades.length,
+      quartoIds: unidades.map((q) => q.id).toList(),
+      disponivel: disponivel,
+      proximaReservaAtiva: proximaReservaAtiva,
+      valorBase: valorBase ?? cat?.preco,
+    );
+  }
+
+  Future<List<RoomCategoryCardModel>> _loadFotos(
+    dynamic dio,
+    String hotelId,
+    List<RoomCategoryCardModel> cards,
+  ) async {
+    final baseUri = Uri.parse(dio.options.baseUrl as String);
+    final serverRoot =
+        '${baseUri.scheme}://${baseUri.host}:${baseUri.port}';
+
+    final futures =
+        cards.map((card) => _loadFotoCard(dio, serverRoot, hotelId, card));
+    final cardsComFoto = await Future.wait(futures, eagerError: false);
+    return cardsComFoto.cast<RoomCategoryCardModel>();
+  }
+
+  Future<RoomCategoryCardModel> _loadFotoCard(
+    dynamic dio,
+    String serverRoot,
+    String hotelId,
+    RoomCategoryCardModel card,
+  ) async {
+    for (final quartoId in card.quartoIds) {
+      try {
+        final response = await dio.get<Map<String, dynamic>>(
+            '$serverRoot/api/uploads/hotels/$hotelId/rooms/$quartoId');
+        final fotos = (response.data?['fotos'] as List<dynamic>?) ?? [];
+        if (fotos.isNotEmpty) {
+          final url =
+              '$serverRoot${(fotos.first as Map<String, dynamic>)['url'] as String}';
+          return card.copyWith(fotoUrl: url);
+        }
+      } catch (_) {}
+    }
+    return card;
+  }
+
+  // Disponibilidade só usa quartos ativos
+  Map<int, Set<DateTime>> _calcularDisponibilidade(
+    List<RoomCategoryCardModel> cards,
+    List<ReservaHotelModel> reservas,
+  ) {
+    return {
+      for (final card in cards.where((c) => c.disponivel))
+        card.categoriaId: computeDiasIndisponiveis(
+          reservas,
+          card.quartoIds,
+          card.totalUnidades,
+          nomeCategoria: card.nomeCategoria,
+        ),
+    };
+  }
+
+  Future<bool> _patchDisponivel(dynamic dio, int quartoId, bool disponivel) async {
+    try {
+      await dio.patch<void>(
+        '/hotel/quartos/$quartoId',
+        data: {'disponivel': disponivel},
+      );
+      return true;
+    } catch (e) {
+      debugPrint('[myRoomsNotifier] Falha ao atualizar quarto $quartoId: $e');
+      return false;
+    }
+  }
+
+  Future<bool> _deleteQuarto(dynamic dio, int quartoId) async {
+    try {
+      await dio.delete<void>('/hotel/quartos/$quartoId');
+      return true;
+    } catch (e) {
+      debugPrint('[myRoomsNotifier] Falha ao deletar quarto $quartoId: $e');
+      return false;
+    }
+  }
+
+  String _fmtDate(DateTime d) =>
+      '${d.year.toString().padLeft(4, '0')}-${d.month.toString().padLeft(2, '0')}-${d.day.toString().padLeft(2, '0')}';
+}
+
+final myRoomsNotifierProvider =
+    NotifierProvider<MyRoomsNotifier, MyRoomsState>(MyRoomsNotifier.new);

--- a/Frontend/lib/features/rooms/presentation/notifiers/my_rooms_state.dart
+++ b/Frontend/lib/features/rooms/presentation/notifiers/my_rooms_state.dart
@@ -1,0 +1,81 @@
+import '../../domain/models/room_category_card.dart';
+import '../../domain/models/reserva_hotel.dart';
+import '../../../rooms/domain/models/hotel_details.dart';
+
+enum FiltroDisponibilidade { todos, disponiveis, indisponiveis }
+
+class MyRoomsState {
+  final List<RoomCategoryCardModel> cards;
+  final List<CategoriaHotelModel> categorias;
+  final List<ReservaHotelModel> reservas;
+  final Map<int, Set<DateTime>> diasIndisponiveisPorCategoria;
+  final String busca;
+  final FiltroDisponibilidade filtroDisponibilidade;
+  final bool loading;
+  final bool deleteInProgress;
+  final bool reservaInProgress;
+  final String? error;
+
+  const MyRoomsState({
+    this.cards = const [],
+    this.categorias = const [],
+    this.reservas = const [],
+    this.diasIndisponiveisPorCategoria = const {},
+    this.busca = '',
+    this.filtroDisponibilidade = FiltroDisponibilidade.todos,
+    this.loading = false,
+    this.deleteInProgress = false,
+    this.reservaInProgress = false,
+    this.error,
+  });
+
+  List<RoomCategoryCardModel> get cardsFiltrados {
+    var resultado = cards;
+
+    if (busca.isNotEmpty) {
+      final query = busca.toLowerCase();
+      resultado = resultado
+          .where((c) => c.nomeCategoria.toLowerCase().contains(query))
+          .toList();
+    }
+
+    switch (filtroDisponibilidade) {
+      case FiltroDisponibilidade.disponiveis:
+        resultado = resultado.where((c) => c.disponivel).toList();
+      case FiltroDisponibilidade.indisponiveis:
+        resultado = resultado.where((c) => !c.disponivel).toList();
+      case FiltroDisponibilidade.todos:
+        break;
+    }
+
+    return resultado;
+  }
+
+  MyRoomsState copyWith({
+    List<RoomCategoryCardModel>? cards,
+    List<CategoriaHotelModel>? categorias,
+    List<ReservaHotelModel>? reservas,
+    Map<int, Set<DateTime>>? diasIndisponiveisPorCategoria,
+    String? busca,
+    FiltroDisponibilidade? filtroDisponibilidade,
+    bool? loading,
+    bool? deleteInProgress,
+    bool? reservaInProgress,
+    String? error,
+    bool clearError = false,
+  }) {
+    return MyRoomsState(
+      cards: cards ?? this.cards,
+      categorias: categorias ?? this.categorias,
+      reservas: reservas ?? this.reservas,
+      diasIndisponiveisPorCategoria:
+          diasIndisponiveisPorCategoria ?? this.diasIndisponiveisPorCategoria,
+      busca: busca ?? this.busca,
+      filtroDisponibilidade: filtroDisponibilidade ?? this.filtroDisponibilidade,
+      loading: loading ?? this.loading,
+      deleteInProgress: deleteInProgress ?? this.deleteInProgress,
+      reservaInProgress: reservaInProgress ?? this.reservaInProgress,
+      error: clearError ? null : (error ?? this.error),
+    );
+  }
+}

--- a/Frontend/lib/features/rooms/presentation/pages/my_rooms_page.dart
+++ b/Frontend/lib/features/rooms/presentation/pages/my_rooms_page.dart
@@ -1,47 +1,29 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
+import '../../../../core/theme/app_colors.dart';
+import '../../domain/models/room_category_card.dart';
+import '../notifiers/my_rooms_notifier.dart';
+import '../notifiers/my_rooms_state.dart';
+import '../widgets/delete_room_dialog.dart';
+import '../widgets/manual_reservation_dialog.dart';
 
-class MyRoomsPage extends StatefulWidget {
+class MyRoomsPage extends ConsumerStatefulWidget {
   const MyRoomsPage({super.key});
 
   @override
-  State<MyRoomsPage> createState() => _MyRoomsPageState();
+  ConsumerState<MyRoomsPage> createState() => _MyRoomsPageState();
 }
 
-class _MyRoomsPageState extends State<MyRoomsPage> {
+class _MyRoomsPageState extends ConsumerState<MyRoomsPage> {
   final TextEditingController _searchController = TextEditingController();
 
-  List<Map<String, dynamic>> rooms = [
-    {
-      'id': '1',
-      'name': 'Grand Hotel\nBudapest',
-      'image': 'https://placehold.co/161x224/png',
-      'amenities': ['wifi', '2 camas', 'café da manhã', 'ar condicionado'],
-      'status': 'active',
-    },
-    {
-      'id': '2',
-      'name': 'Grand Hotel\nBudapest',
-      'image': 'https://placehold.co/161x224/png',
-      'amenities': ['wifi', '2 camas', 'café da manhã', 'ar condicionado'],
-      'status': 'active',
-    },
-    {
-      'id': '3',
-      'name': 'Grand Hotel\nBudapest',
-      'image': 'https://placehold.co/161x224/png',
-      'amenities': ['café da manhã'],
-      'status': 'inactive',
-    },
-  ];
-
-  List<Map<String, dynamic>> get filteredRooms {
-    if (_searchController.text.isEmpty) return rooms;
-    return rooms.where((room) {
-      final name = room['name'].toString().toLowerCase();
-      final query = _searchController.text.toLowerCase();
-      return name.contains(query);
-    }).toList();
+  @override
+  void initState() {
+    super.initState();
+    Future.microtask(() {
+      ref.read(myRoomsNotifierProvider.notifier).load();
+    });
   }
 
   @override
@@ -52,67 +34,32 @@ class _MyRoomsPageState extends State<MyRoomsPage> {
 
   @override
   Widget build(BuildContext context) {
+    final state = ref.watch(myRoomsNotifierProvider);
+
     return Scaffold(
       backgroundColor: Colors.white,
       body: Stack(
         children: [
           Column(
             children: [
-              _buildHeaderAndSearch(),
-              Expanded(
-                child: ListView.builder(
-                  padding: const EdgeInsets.only(top: 16, bottom: 80, left: 16, right: 16),
-                  itemCount: filteredRooms.length,
-                  itemBuilder: (context, index) {
-                    return _buildRoomCard(filteredRooms[index]);
-                  },
-                ),
-              ),
+              _buildHeader(state),
+              _buildFiltroChips(state),
+              Expanded(child: _buildBody(state)),
             ],
           ),
-          // Floating Adicionar Button
-          Positioned(
-            bottom: 24,
-            left: 0,
-            right: 0,
-            child: Center(
-              child: SizedBox(
-                height: 40,
-                width: 185,
-                child: ElevatedButton(
-                  onPressed: () {
-                    context.push('/add_room');
-                  },
-                  style: ElevatedButton.styleFrom(
-                    backgroundColor: const Color(0xFFF19D75), // Soft Orange as in prototype
-                    shape: RoundedRectangleBorder(
-                      borderRadius: BorderRadius.circular(11),
-                      side: const BorderSide(color: Color(0xFFEC6725)), // Darker orange border
-                    ),
-                    elevation: 0,
-                  ),
-                  child: const Text(
-                    'Adicionar',
-                    style: TextStyle(
-                      color: Color(0xFF182541), // Dark Blue
-                      fontSize: 16,
-                      fontWeight: FontWeight.w700,
-                    ),
-                  ),
-                ),
-              ),
-            ),
-          ),
+          _buildAddButton(state),
         ],
       ),
     );
   }
 
-  Widget _buildHeaderAndSearch() {
+  // ── Header ────────────────────────────────────────────────────────────────
+
+  Widget _buildHeader(MyRoomsState state) {
     return Container(
       width: double.infinity,
       decoration: const BoxDecoration(
-        color: Color(0xFF182541),
+        color: AppColors.primary,
         borderRadius: BorderRadius.only(
           bottomLeft: Radius.circular(27),
           bottomRight: Radius.circular(27),
@@ -124,72 +71,81 @@ class _MyRoomsPageState extends State<MyRoomsPage> {
           Row(
             mainAxisAlignment: MainAxisAlignment.spaceBetween,
             children: [
-              // Back Button
               Container(
                 width: 40,
                 height: 40,
                 decoration: BoxDecoration(
-                  color: Colors.white.withOpacity(0.2),
+                  color: Colors.white.withValues(alpha: 0.2),
                   shape: BoxShape.circle,
                 ),
-                child: IconButton(
-                  icon: const Icon(Icons.arrow_back_ios_new, color: Colors.white, size: 18),
-                  onPressed: () => context.canPop() ? context.pop() : context.go('/profile/host'),
+                child: Semantics(
+                  label: 'Voltar',
+                  child: IconButton(
+                    icon: const Icon(Icons.arrow_back_ios_new,
+                        color: Colors.white, size: 18),
+                    onPressed: () => context.canPop()
+                        ? context.pop()
+                        : context.go('/profile/host'),
+                  ),
                 ),
               ),
-              Column(
-                children: const [
-                  Text(
-                    'RESERVAQUI',
-                    style: TextStyle(
-                      color: Colors.white,
-                      fontSize: 20,
-                      fontWeight: FontWeight.w700,
-                    ),
-                  ),
+              const Column(
+                children: [
+                  Text('RESERVAQUI',
+                      style: TextStyle(
+                          color: Colors.white,
+                          fontSize: 20,
+                          fontWeight: FontWeight.w700)),
                   SizedBox(height: 4),
-                  Text(
-                    'Meus Quartos',
-                    style: TextStyle(
-                      color: Colors.white,
-                      fontSize: 16,
-                      fontWeight: FontWeight.w500,
-                    ),
-                  ),
+                  Text('Meus Quartos',
+                      style: TextStyle(
+                          color: Colors.white,
+                          fontSize: 16,
+                          fontWeight: FontWeight.w500)),
                 ],
               ),
               Container(
                 width: 40,
                 height: 40,
                 decoration: BoxDecoration(
-                  color: Colors.white.withOpacity(0.2),
+                  color: Colors.white.withValues(alpha: 0.2),
                   shape: BoxShape.circle,
                 ),
-                child: IconButton(
-                  icon: const Icon(Icons.notifications_none, color: Colors.white),
-                  onPressed: () => context.go('/notifications'),
-                  padding: EdgeInsets.zero,
+                child: Semantics(
+                  label: 'Notificações',
+                  child: IconButton(
+                    icon: const Icon(Icons.notifications_none,
+                        color: Colors.white),
+                    onPressed: () => context.go('/notifications'),
+                    padding: EdgeInsets.zero,
+                  ),
                 ),
               ),
             ],
           ),
           const SizedBox(height: 24),
-          // Search bar inside the blue header
           Container(
             height: 44,
             decoration: BoxDecoration(
               color: Colors.white,
               borderRadius: BorderRadius.circular(23),
             ),
-            child: TextField(
-              controller: _searchController,
-              onChanged: (value) => setState(() {}),
-              decoration: InputDecoration(
-                hintText: 'Pesquisar...',
-                hintStyle: TextStyle(color: Colors.grey[400], fontSize: 14),
-                border: InputBorder.none,
-                suffixIcon: const Icon(Icons.search, color: Color(0xFFEC6725)), // Orange icon on right
-                contentPadding: const EdgeInsets.symmetric(horizontal: 20, vertical: 14),
+            child: Semantics(
+              label: 'Pesquisar quartos por nome',
+              child: TextField(
+                controller: _searchController,
+                onChanged: (v) =>
+                    ref.read(myRoomsNotifierProvider.notifier).setBusca(v),
+                decoration: InputDecoration(
+                  hintText: 'Pesquisar por tipo de quarto...',
+                  hintStyle:
+                      TextStyle(color: Colors.grey[400], fontSize: 14),
+                  border: InputBorder.none,
+                  suffixIcon: const Icon(Icons.search,
+                      color: AppColors.secondary),
+                  contentPadding: const EdgeInsets.symmetric(
+                      horizontal: 20, vertical: 14),
+                ),
               ),
             ),
           ),
@@ -198,154 +154,829 @@ class _MyRoomsPageState extends State<MyRoomsPage> {
     );
   }
 
-  Widget _buildRoomCard(Map<String, dynamic> room) {
+  // ── Filtro Disponível / Indisponível ──────────────────────────────────────
+
+  Widget _buildFiltroChips(MyRoomsState state) {
+    final filtro = state.filtroDisponibilidade;
+    final notifier = ref.read(myRoomsNotifierProvider.notifier);
+
+    return SizedBox(
+      height: 48,
+      child: ListView(
+        padding: const EdgeInsets.symmetric(horizontal: 16),
+        scrollDirection: Axis.horizontal,
+        children: [
+          Center(child: _chip('Todos', filtro == FiltroDisponibilidade.todos,
+              () => notifier.setFiltro(FiltroDisponibilidade.todos))),
+          const SizedBox(width: 8),
+          Center(child: _chip('Disponíveis',
+              filtro == FiltroDisponibilidade.disponiveis,
+              () => notifier.setFiltro(FiltroDisponibilidade.disponiveis))),
+          const SizedBox(width: 8),
+          Center(child: _chip('Indisponíveis',
+              filtro == FiltroDisponibilidade.indisponiveis,
+              () => notifier.setFiltro(FiltroDisponibilidade.indisponiveis))),
+        ],
+      ),
+    );
+  }
+
+  Widget _chip(String label, bool selected, VoidCallback onTap) {
+    return Semantics(
+      label: '$label${selected ? ', selecionado' : ''}',
+      child: FilterChip(
+        label: Text(label),
+        selected: selected,
+        onSelected: (_) => onTap(),
+        selectedColor: AppColors.secondary.withValues(alpha: 0.2),
+        checkmarkColor: AppColors.secondary,
+        visualDensity: VisualDensity.compact,
+        labelPadding: const EdgeInsets.only(left: 2, right: 6),
+        labelStyle: TextStyle(
+          color: selected ? AppColors.secondary : AppColors.greyText,
+          fontWeight:
+              selected ? FontWeight.w600 : FontWeight.normal,
+        ),
+      ),
+    );
+  }
+
+  // ── Body ──────────────────────────────────────────────────────────────────
+
+  Widget _buildBody(MyRoomsState state) {
+    if (state.loading) return _buildLoading();
+    if (state.error != null) return _buildError(state.error!);
+
+    final cards = state.cardsFiltrados;
+    if (cards.isEmpty && state.cards.isEmpty) return _buildEmpty();
+    if (cards.isEmpty) return _buildEmptyFilter();
+
+    return RefreshIndicator(
+      onRefresh: () =>
+          ref.read(myRoomsNotifierProvider.notifier).refresh(),
+      color: AppColors.secondary,
+      child: ListView.builder(
+        padding: const EdgeInsets.only(
+            top: 16, bottom: 100, left: 16, right: 16),
+        itemCount: cards.length,
+        itemBuilder: (context, index) {
+          final card = cards[index];
+          return card.disponivel
+              ? _buildCardAtivo(state, card)
+              : _buildCardInativo(state, card);
+        },
+      ),
+    );
+  }
+
+  Widget _buildLoading() => const Center(
+      child: CircularProgressIndicator(color: AppColors.secondary));
+
+  Widget _buildError(String mensagem) {
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.all(32),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            const Icon(Icons.error_outline,
+                color: AppColors.greyText, size: 48),
+            const SizedBox(height: 16),
+            Text(mensagem,
+                textAlign: TextAlign.center,
+                style: const TextStyle(
+                    color: AppColors.greyText, fontSize: 15)),
+            const SizedBox(height: 24),
+            ElevatedButton.icon(
+              onPressed: () =>
+                  ref.read(myRoomsNotifierProvider.notifier).refresh(),
+              icon: const Icon(Icons.refresh),
+              label: const Text('Tentar novamente'),
+              style: ElevatedButton.styleFrom(
+                backgroundColor: AppColors.primary,
+                foregroundColor: Colors.white,
+                shape: RoundedRectangleBorder(
+                    borderRadius: BorderRadius.circular(11)),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildEmpty() {
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.all(32),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            const Icon(Icons.hotel_outlined,
+                color: AppColors.greyText, size: 64),
+            const SizedBox(height: 16),
+            const Text('Nenhum quarto cadastrado',
+                style: TextStyle(
+                    color: AppColors.primary,
+                    fontSize: 18,
+                    fontWeight: FontWeight.w700)),
+            const SizedBox(height: 8),
+            const Text('Adicione o primeiro tipo de quarto do seu hotel.',
+                textAlign: TextAlign.center,
+                style:
+                    TextStyle(color: AppColors.greyText, fontSize: 14)),
+            const SizedBox(height: 24),
+            Semantics(
+              label: 'Adicionar primeiro quarto',
+              child: ElevatedButton.icon(
+                onPressed: () => context.push('/add_room'),
+                icon: const Icon(Icons.add),
+                label: const Text('Adicionar quarto'),
+                style: ElevatedButton.styleFrom(
+                  backgroundColor: AppColors.secondary,
+                  foregroundColor: Colors.white,
+                  shape: RoundedRectangleBorder(
+                      borderRadius: BorderRadius.circular(11)),
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildEmptyFilter() {
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.all(32),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            const Icon(Icons.search_off,
+                color: AppColors.greyText, size: 48),
+            const SizedBox(height: 16),
+            const Text('Nenhum resultado',
+                style: TextStyle(
+                    color: AppColors.primary,
+                    fontSize: 16,
+                    fontWeight: FontWeight.w600)),
+            const SizedBox(height: 8),
+            const Text('Tente outro nome ou ajuste o filtro.',
+                textAlign: TextAlign.center,
+                style:
+                    TextStyle(color: AppColors.greyText, fontSize: 14)),
+          ],
+        ),
+      ),
+    );
+  }
+
+  // ── Card Ativo ────────────────────────────────────────────────────────────
+
+  Widget _buildCardAtivo(MyRoomsState state, RoomCategoryCardModel card) {
     return Container(
       margin: const EdgeInsets.only(bottom: 16),
-      height: 224, // Exact height from prototype
       decoration: BoxDecoration(
         color: Colors.white,
         borderRadius: BorderRadius.circular(11),
         border: Border.all(color: const Color(0x3F182541)),
       ),
-      child: Row(
+      child: Column(
         children: [
-          // Image Left
-          ClipRRect(
-            borderRadius: const BorderRadius.only(
-              topLeft: Radius.circular(11),
-              bottomLeft: Radius.circular(11),
-            ),
-            child: Image.network(
-              room['image'],
-              width: 161,
-              height: double.infinity,
-              fit: BoxFit.cover,
-            ),
-          ),
-          // Content Right
-          Expanded(
-            child: Padding(
-              padding: const EdgeInsets.all(12.0),
-              child: Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  Row(
-                    mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                    crossAxisAlignment: CrossAxisAlignment.start,
-                    children: [
-                      Expanded(
-                        child: Text(
-                          room['name'],
-                          style: const TextStyle(
-                            color: Color(0xFF182541),
-                            fontSize: 18,
-                            fontWeight: FontWeight.w700,
-                            height: 1.2,
-                          ),
-                          maxLines: 2,
-                          overflow: TextOverflow.ellipsis,
-                        ),
-                      ),
-                      // Edit button
-                      GestureDetector(
-                        onTap: () => context.push('/edit_room/${room['id']}'),
-                        child: Container(
-                          width: 24,
-                          height: 24,
-                          decoration: BoxDecoration(
-                            color: const Color(0xFFFEE8DB),
-                            shape: BoxShape.circle,
-                            border: Border.all(color: const Color(0xFFEC6725)),
-                          ),
-                          child: const Icon(
-                            Icons.edit,
-                            color: Color(0xFFEC6725),
-                            size: 14,
-                          ),
-                        ),
-                      ),
-                    ],
-                  ),
-                  const SizedBox(height: 8),
-                  // Amenities
-                  Expanded(
-                    child: Wrap(
-                      spacing: 4,
-                      runSpacing: 4,
-                      children: (room['amenities'] as List<String>).map((amenity) {
-                        return Container(
-                          padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
-                          decoration: BoxDecoration(
-                            color: const Color(0xFFF5F5F5),
-                            borderRadius: BorderRadius.circular(8),
-                          ),
-                          child: Row(
-                            mainAxisSize: MainAxisSize.min,
-                            children: [
-                              Icon(
-                                _getIconForAmenity(amenity),
-                                size: 12,
-                                color: const Color(0xFF7F8697),
-                              ),
-                              const SizedBox(width: 4),
-                              Text(
-                                amenity,
-                                style: const TextStyle(
-                                  color: Color(0xFF7F8697),
-                                  fontSize: 10,
-                                  fontWeight: FontWeight.w600,
+          SizedBox(
+            height: 120,
+            child: Row(
+              children: [
+                ClipRRect(
+                  borderRadius:
+                      const BorderRadius.only(topLeft: Radius.circular(11)),
+                  child: card.fotoUrl != null
+                      ? Image.network(card.fotoUrl!,
+                          width: 110,
+                          height: double.infinity,
+                          fit: BoxFit.cover,
+                          errorBuilder: (_, __, ___) =>
+                              _buildFotoPlaceholder())
+                      : _buildFotoPlaceholder(),
+                ),
+                Expanded(
+                  child: Padding(
+                    padding: const EdgeInsets.all(12),
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Row(
+                          crossAxisAlignment: CrossAxisAlignment.start,
+                          children: [
+                            Expanded(
+                              child: Text(card.nomeCategoria,
+                                  style: const TextStyle(
+                                      color: AppColors.primary,
+                                      fontSize: 17,
+                                      fontWeight: FontWeight.w700,
+                                      height: 1.15),
+                                  maxLines: 2,
+                                  overflow: TextOverflow.ellipsis),
+                            ),
+                            Semantics(
+                              label: 'Editar ${card.nomeCategoria}',
+                              child: GestureDetector(
+                                onTap: () => context.push(
+                                    '/edit_room/${card.quartoIds.first}'),
+                                child: Container(
+                                  width: 28,
+                                  height: 28,
+                                  decoration: BoxDecoration(
+                                    color: const Color(0xFFFEE8DB),
+                                    shape: BoxShape.circle,
+                                    border: Border.all(
+                                        color: AppColors.secondary),
+                                  ),
+                                  child: const Icon(Icons.edit,
+                                      color: AppColors.secondary,
+                                      size: 14),
                                 ),
                               ),
-                            ],
+                            ),
+                          ],
+                        ),
+                        const SizedBox(height: 6),
+                        _infoRow(Icons.meeting_room_outlined,
+                            '${card.totalUnidades} unidade${card.totalUnidades != 1 ? 's' : ''}'),
+                        if (card.valorBase != null) ...[
+                          const SizedBox(height: 4),
+                          _infoRow(Icons.attach_money,
+                              'R\$ ${card.valorBase!.toStringAsFixed(2)}/noite'),
+                        ],
+                        if (card.descricao != null) ...[
+                          const SizedBox(height: 4),
+                          Expanded(
+                            child: Text(card.descricao!,
+                                style: const TextStyle(
+                                    color: AppColors.greyText,
+                                    fontSize: 11),
+                                maxLines: 2,
+                                overflow: TextOverflow.ellipsis),
                           ),
-                        );
-                      }).toList(),
+                        ],
+                      ],
                     ),
                   ),
-                  // Ver mais button
-                  SizedBox(
-                    width: double.infinity,
-                    height: 38,
-                    child: ElevatedButton(
-                      onPressed: () => context.push('/hotel_details/${room['id']}'),
-                      style: ElevatedButton.styleFrom(
-                        backgroundColor: const Color(0xFF182541),
-                        shape: RoundedRectangleBorder(
-                          borderRadius: BorderRadius.circular(11),
-                        ),
-                      ),
-                      child: const Text(
-                        'Ver Mais',
-                        style: TextStyle(
-                          color: Colors.white,
-                          fontSize: 14,
-                          fontWeight: FontWeight.w700,
-                        ),
-                      ),
-                    ),
-                  ),
-                ],
-              ),
+                ),
+              ],
             ),
           ),
+          _buildBarraAcoes([
+            _buildAcaoBtn(
+                icon: Icons.calendar_month_outlined,
+                label: 'Reserva manual',
+                onTap: () => _abrirReservaManual(state, card)),
+            const VerticalDivider(
+                width: 1, thickness: 1, color: Color(0x1F182541)),
+            _buildAcaoBtn(
+                icon: Icons.block,
+                label: 'Desativar',
+                cor: Colors.orange[700]!,
+                onTap: () => _abrirDesativar(state, card)),
+          ]),
         ],
       ),
     );
   }
 
-  IconData _getIconForAmenity(String amenity) {
-    switch (amenity.toLowerCase()) {
-      case 'wifi':
-        return Icons.wifi;
-      case '2 camas':
-      case 'camas':
-        return Icons.bed;
-      case 'café da manhã':
-        return Icons.coffee;
-      case 'ar condicionado':
-        return Icons.ac_unit;
-      default:
-        return Icons.check_circle_outline;
-    }
+  // ── Card Inativo ──────────────────────────────────────────────────────────
+
+  Widget _buildCardInativo(MyRoomsState state, RoomCategoryCardModel card) {
+    return Container(
+      margin: const EdgeInsets.only(bottom: 16),
+      decoration: BoxDecoration(
+        color: const Color(0xFFF7F7F7),
+        borderRadius: BorderRadius.circular(11),
+        border: Border.all(color: const Color(0x3F182541)),
+      ),
+      child: Column(
+        children: [
+          SizedBox(
+            height: 110,
+            child: Row(
+              children: [
+                // Foto com overlay de inativo
+                ClipRRect(
+                  borderRadius: const BorderRadius.only(
+                      topLeft: Radius.circular(11)),
+                  child: Stack(
+                    children: [
+                      Opacity(
+                        opacity: 0.45,
+                        child: card.fotoUrl != null
+                            ? Image.network(card.fotoUrl!,
+                                width: 110,
+                                height: double.infinity,
+                                fit: BoxFit.cover,
+                                errorBuilder: (_, __, ___) =>
+                                    _buildFotoPlaceholder(inativo: true))
+                            : _buildFotoPlaceholder(inativo: true),
+                      ),
+                      Positioned(
+                        bottom: 6,
+                        left: 0,
+                        right: 0,
+                        child: Center(
+                          child: Container(
+                            padding: const EdgeInsets.symmetric(
+                                horizontal: 8, vertical: 3),
+                            decoration: BoxDecoration(
+                              color:
+                                  Colors.black.withValues(alpha: 0.55),
+                              borderRadius: BorderRadius.circular(20),
+                            ),
+                            child: const Text('Desativado',
+                                style: TextStyle(
+                                    color: Colors.white,
+                                    fontSize: 10,
+                                    fontWeight: FontWeight.w600)),
+                          ),
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+                Expanded(
+                  child: Padding(
+                    padding: const EdgeInsets.all(12),
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Text(card.nomeCategoria,
+                            style: const TextStyle(
+                                color: AppColors.greyText,
+                                fontSize: 16,
+                                fontWeight: FontWeight.w700,
+                                height: 1.15),
+                            maxLines: 2,
+                            overflow: TextOverflow.ellipsis),
+                        const SizedBox(height: 6),
+                        _infoRow(
+                            Icons.meeting_room_outlined,
+                            '${card.totalUnidades} unidade${card.totalUnidades != 1 ? 's' : ''}',
+                            cor: AppColors.greyText),
+                        const SizedBox(height: 4),
+                        // Info de reserva ativa
+                        card.proximaReservaAtiva != null
+                            ? _infoRow(Icons.event_busy,
+                                'Próxima reserva: ${_fmtData(card.proximaReservaAtiva!)}',
+                                cor: Colors.orange[700]!)
+                            : _infoRow(Icons.check_circle_outline,
+                                'Sem reservas ativas',
+                                cor: Colors.green[600]!),
+                      ],
+                    ),
+                  ),
+                ),
+              ],
+            ),
+          ),
+          _buildBarraAcoes([
+            _buildAcaoBtn(
+                icon: Icons.play_circle_outline,
+                label: 'Reativar',
+                cor: Colors.green[700]!,
+                onTap: () => _abrirReativar(card)),
+            const VerticalDivider(
+                width: 1, thickness: 1, color: Color(0x1F182541)),
+            _buildAcaoBtn(
+                icon: Icons.delete_outline,
+                label: 'Remover',
+                cor: Colors.red[600]!,
+                onTap: () => _abrirRemoverInativo(card)),
+          ]),
+        ],
+      ),
+    );
   }
+
+  // ── Shared card widgets ───────────────────────────────────────────────────
+
+  Widget _buildBarraAcoes(List<Widget> children) {
+    return Container(
+      decoration: const BoxDecoration(
+        border: Border(top: BorderSide(color: Color(0x1F182541))),
+        borderRadius: BorderRadius.only(
+            bottomLeft: Radius.circular(11),
+            bottomRight: Radius.circular(11)),
+      ),
+      child: IntrinsicHeight(child: Row(children: children)),
+    );
+  }
+
+  Widget _buildAcaoBtn({
+    required IconData icon,
+    required String label,
+    required VoidCallback onTap,
+    Color cor = AppColors.primary,
+  }) {
+    return Expanded(
+      child: Semantics(
+        label: label,
+        button: true,
+        child: InkWell(
+          onTap: onTap,
+          borderRadius: const BorderRadius.only(
+              bottomLeft: Radius.circular(11),
+              bottomRight: Radius.circular(11)),
+          child: Padding(
+            padding: const EdgeInsets.symmetric(vertical: 10),
+            child: Row(
+              mainAxisAlignment: MainAxisAlignment.center,
+              children: [
+                Icon(icon, size: 15, color: cor),
+                const SizedBox(width: 5),
+                Text(label,
+                    style: TextStyle(
+                        color: cor,
+                        fontSize: 12,
+                        fontWeight: FontWeight.w600)),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget _infoRow(IconData icon, String text,
+      {Color cor = AppColors.greyText}) {
+    return Row(
+      children: [
+        Icon(icon, size: 13, color: cor),
+        const SizedBox(width: 4),
+        Expanded(
+          child: Text(text,
+              style: TextStyle(color: cor, fontSize: 11),
+              overflow: TextOverflow.ellipsis),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildFotoPlaceholder({bool inativo = false}) {
+    return Container(
+      width: 110,
+      color: inativo
+          ? const Color(0xFFDDDDDD)
+          : AppColors.bgSecondary,
+      child: Icon(Icons.hotel,
+          color: inativo
+              ? Colors.grey[400]
+              : AppColors.greyText,
+          size: 36),
+    );
+  }
+
+  Widget _buildAddButton(MyRoomsState state) {
+    return Positioned(
+      bottom: 24,
+      left: 0,
+      right: 0,
+      child: Center(
+        child: SizedBox(
+          height: 40,
+          width: 185,
+          child: Semantics(
+            label: 'Adicionar novo tipo de quarto',
+            child: ElevatedButton(
+              onPressed:
+                  state.loading ? null : () => context.push('/add_room'),
+              style: ElevatedButton.styleFrom(
+                backgroundColor: const Color(0xFFF19D75),
+                shape: RoundedRectangleBorder(
+                  borderRadius: BorderRadius.circular(11),
+                  side:
+                      const BorderSide(color: AppColors.secondary),
+                ),
+                elevation: 2,
+              ),
+              child: const Text('Adicionar',
+                  style: TextStyle(
+                      color: AppColors.primary,
+                      fontSize: 16,
+                      fontWeight: FontWeight.w700)),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  // ── Actions ───────────────────────────────────────────────────────────────
+
+  void _abrirDesativar(MyRoomsState state, RoomCategoryCardModel card) {
+    final notifier = ref.read(myRoomsNotifierProvider.notifier);
+    final temReserva = notifier.temReservaAtiva(card.quartoIds);
+    final proxima   = notifier.proximaReservaAtiva(card.quartoIds);
+
+    showDialog<void>(
+      context: context,
+      barrierDismissible: false,
+      builder: (_) => DeleteRoomDialog(
+        nomeCategoria: card.nomeCategoria,
+        totalUnidades: card.totalUnidades,
+        temReservaAtiva: temReserva,
+        proximaReservaAtiva: proxima,
+        onConfirm: (quantidade, {required bool permanente}) async {
+          final resultado = await notifier.deativarUnidades(
+              card.categoriaId, quantidade,
+              permanente: permanente);
+
+          if (!mounted) return;
+          _mostrarSnackbarAcao(
+            resultado,
+            permanente ? 'removida' : 'desativada',
+          );
+        },
+      ),
+    );
+  }
+
+  void _abrirReativar(RoomCategoryCardModel card) {
+    showDialog<bool?>(
+      context: context,
+      builder: (_) => Dialog(
+        backgroundColor: Colors.white,
+        shape:
+            RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
+        child: Padding(
+          padding: const EdgeInsets.fromLTRB(24, 20, 24, 24),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              const Icon(Icons.play_circle_outline,
+                  color: Colors.green, size: 44),
+              const SizedBox(height: 12),
+              const Text('Reativar unidades',
+                  textAlign: TextAlign.center,
+                  style: TextStyle(
+                      color: AppColors.secondary,
+                      fontSize: 22,
+                      fontWeight: FontWeight.w700)),
+              const SizedBox(height: 4),
+              Text(card.nomeCategoria,
+                  textAlign: TextAlign.center,
+                  style: const TextStyle(
+                      color: AppColors.greyText, fontSize: 13)),
+              const SizedBox(height: 12),
+              Text(
+                'As ${card.totalUnidades} unidade${card.totalUnidades != 1 ? 's' : ''} voltarão a aceitar reservas.',
+                textAlign: TextAlign.center,
+                style: const TextStyle(
+                    color: AppColors.greyText, fontSize: 14, height: 1.4),
+              ),
+              const SizedBox(height: 24),
+              Row(
+                children: [
+                  Expanded(
+                    child: OutlinedButton(
+                      onPressed: () => Navigator.of(context).pop(false),
+                      style: OutlinedButton.styleFrom(
+                        side: const BorderSide(color: AppColors.primary),
+                        shape: RoundedRectangleBorder(
+                            borderRadius: BorderRadius.circular(11)),
+                        padding:
+                            const EdgeInsets.symmetric(vertical: 13),
+                      ),
+                      child: const Text('Cancelar',
+                          style: TextStyle(
+                              color: AppColors.primary,
+                              fontWeight: FontWeight.w600)),
+                    ),
+                  ),
+                  const SizedBox(width: 12),
+                  Expanded(
+                    child: ElevatedButton(
+                      onPressed: () => Navigator.of(context).pop(true),
+                      style: ElevatedButton.styleFrom(
+                        backgroundColor: Colors.green[700],
+                        shape: RoundedRectangleBorder(
+                            borderRadius: BorderRadius.circular(11)),
+                        padding:
+                            const EdgeInsets.symmetric(vertical: 13),
+                        elevation: 0,
+                      ),
+                      child: const Text('Reativar',
+                          style: TextStyle(
+                              color: Colors.white,
+                              fontWeight: FontWeight.w700)),
+                    ),
+                  ),
+                ],
+              ),
+            ],
+          ),
+        ),
+      ),
+    ).then((confirmado) async {
+      if (confirmado != true || !mounted) return;
+      final resultado = await ref
+          .read(myRoomsNotifierProvider.notifier)
+          .reativarUnidades(card.categoriaId);
+      if (!mounted) return;
+      _mostrarSnackbarAcao(resultado, 'reativada');
+    });
+  }
+
+  void _abrirRemoverInativo(RoomCategoryCardModel card) {
+    final notifier = ref.read(myRoomsNotifierProvider.notifier);
+    final bloqueio = notifier.verificarBloqueioExclusao(card.categoriaId);
+
+    if (bloqueio != null) {
+      // Exclusão bloqueada — mostra aviso sem opção de confirmar
+      showDialog<void>(
+        context: context,
+        builder: (_) => Dialog(
+          backgroundColor: Colors.white,
+          shape: RoundedRectangleBorder(
+              borderRadius: BorderRadius.circular(16)),
+          child: Padding(
+            padding: const EdgeInsets.fromLTRB(24, 20, 24, 24),
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                Icon(Icons.event_busy, color: Colors.orange[700], size: 44),
+                const SizedBox(height: 12),
+                Text('Exclusão bloqueada',
+                    textAlign: TextAlign.center,
+                    style: TextStyle(
+                        color: Colors.orange[700],
+                        fontSize: 20,
+                        fontWeight: FontWeight.w700)),
+                const SizedBox(height: 12),
+                Text(bloqueio,
+                    textAlign: TextAlign.center,
+                    style: const TextStyle(
+                        color: AppColors.greyText,
+                        fontSize: 14,
+                        height: 1.5)),
+                const SizedBox(height: 24),
+                SizedBox(
+                  width: double.infinity,
+                  child: ElevatedButton(
+                    onPressed: () => Navigator.of(context).pop(),
+                    style: ElevatedButton.styleFrom(
+                      backgroundColor: AppColors.primary,
+                      shape: RoundedRectangleBorder(
+                          borderRadius: BorderRadius.circular(11)),
+                      padding:
+                          const EdgeInsets.symmetric(vertical: 13),
+                      elevation: 0,
+                    ),
+                    child: const Text('Entendido',
+                        style: TextStyle(
+                            color: Colors.white,
+                            fontWeight: FontWeight.w700)),
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ),
+      );
+      return;
+    }
+
+    // Exclusão permitida — confirmar
+    showDialog<bool?>(
+      context: context,
+      builder: (_) => Dialog(
+        backgroundColor: Colors.white,
+        shape:
+            RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
+        child: Padding(
+          padding: const EdgeInsets.fromLTRB(24, 20, 24, 24),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Icon(Icons.delete_forever, color: Colors.red[600], size: 44),
+              const SizedBox(height: 12),
+              const Text('Remover definitivamente',
+                  textAlign: TextAlign.center,
+                  style: TextStyle(
+                      color: AppColors.secondary,
+                      fontSize: 20,
+                      fontWeight: FontWeight.w700)),
+              const SizedBox(height: 4),
+              Text(card.nomeCategoria,
+                  textAlign: TextAlign.center,
+                  style: const TextStyle(
+                      color: AppColors.greyText, fontSize: 13)),
+              const SizedBox(height: 12),
+              const Text(
+                'Esta ação excluirá as unidades permanentemente e não pode ser desfeita.',
+                textAlign: TextAlign.center,
+                style: TextStyle(
+                    color: AppColors.greyText, fontSize: 14, height: 1.4),
+              ),
+              const SizedBox(height: 24),
+              Row(
+                children: [
+                  Expanded(
+                    child: OutlinedButton(
+                      onPressed: () => Navigator.of(context).pop(false),
+                      style: OutlinedButton.styleFrom(
+                        side: const BorderSide(color: AppColors.primary),
+                        shape: RoundedRectangleBorder(
+                            borderRadius: BorderRadius.circular(11)),
+                        padding:
+                            const EdgeInsets.symmetric(vertical: 13),
+                      ),
+                      child: const Text('Cancelar',
+                          style: TextStyle(
+                              color: AppColors.primary,
+                              fontWeight: FontWeight.w600)),
+                    ),
+                  ),
+                  const SizedBox(width: 12),
+                  Expanded(
+                    child: ElevatedButton(
+                      onPressed: () => Navigator.of(context).pop(true),
+                      style: ElevatedButton.styleFrom(
+                        backgroundColor: Colors.red[600],
+                        shape: RoundedRectangleBorder(
+                            borderRadius: BorderRadius.circular(11)),
+                        padding:
+                            const EdgeInsets.symmetric(vertical: 13),
+                        elevation: 0,
+                      ),
+                      child: const Text('Remover',
+                          style: TextStyle(
+                              color: Colors.white,
+                              fontWeight: FontWeight.w700)),
+                    ),
+                  ),
+                ],
+              ),
+            ],
+          ),
+        ),
+      ),
+    ).then((confirmado) async {
+      if (confirmado != true || !mounted) return;
+      final resultado = await ref
+          .read(myRoomsNotifierProvider.notifier)
+          .excluirUnidadesInativas(card.categoriaId);
+      if (!mounted) return;
+      _mostrarSnackbarAcao(resultado, 'removida');
+    });
+  }
+
+  void _abrirReservaManual(MyRoomsState state, RoomCategoryCardModel card) {
+    final diasIndisponiveis =
+        state.diasIndisponiveisPorCategoria[card.categoriaId] ?? {};
+
+    showDialog<bool?>(
+      context: context,
+      builder: (_) => ManualReservationDialog(
+        nomeCategoria: card.nomeCategoria,
+        valorBase: card.valorBase,
+        diasIndisponiveis: diasIndisponiveis,
+        onConfirm: ({
+          required DateTime checkin,
+          required DateTime checkout,
+          required double valorTotal,
+        }) async {
+          return ref
+              .read(myRoomsNotifierProvider.notifier)
+              .criarReservaManual(
+                categoriaId: card.categoriaId,
+                checkin: checkin,
+                checkout: checkout,
+                valorTotal: valorTotal,
+              );
+        },
+      ),
+    ).then((sucesso) {
+      if (!mounted || sucesso != true) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(
+          content: Text('Reserva manual criada com sucesso.'),
+          backgroundColor: Colors.green,
+        ),
+      );
+    });
+  }
+
+  void _mostrarSnackbarAcao(Map<String, int> resultado, String verbo) {
+    final sucesso = resultado['sucesso'] ?? 0;
+    final falha   = resultado['falha'] ?? 0;
+    final msg = falha == 0
+        ? '$sucesso unidade${sucesso != 1 ? 's' : ''} ${verbo}s com sucesso.'
+        : '$sucesso/${sucesso + falha} unidade${sucesso != 1 ? 's' : ''} ${verbo}s. $falha não puderam ser processadas.';
+    ScaffoldMessenger.of(context).showSnackBar(SnackBar(
+      content: Text(msg),
+      backgroundColor: falha == 0 ? Colors.green[700] : Colors.orange[700],
+    ));
+  }
+
+  String _fmtData(DateTime d) =>
+      '${d.day.toString().padLeft(2, '0')}/${d.month.toString().padLeft(2, '0')}/${d.year}';
 }

--- a/Frontend/lib/features/rooms/presentation/widgets/delete_room_dialog.dart
+++ b/Frontend/lib/features/rooms/presentation/widgets/delete_room_dialog.dart
@@ -1,0 +1,362 @@
+import 'package:flutter/material.dart';
+import '../../../../core/theme/app_colors.dart';
+
+class DeleteRoomDialog extends StatefulWidget {
+  final String nomeCategoria;
+  final int totalUnidades;
+  final bool temReservaAtiva;
+  final DateTime? proximaReservaAtiva;
+  final Future<void> Function(int quantidade, {required bool permanente}) onConfirm;
+
+  const DeleteRoomDialog({
+    super.key,
+    required this.nomeCategoria,
+    required this.totalUnidades,
+    required this.temReservaAtiva,
+    required this.onConfirm,
+    this.proximaReservaAtiva,
+  });
+
+  @override
+  State<DeleteRoomDialog> createState() => _DeleteRoomDialogState();
+}
+
+class _DeleteRoomDialogState extends State<DeleteRoomDialog> {
+  // confirm → quantity → tipo → (warning)
+  String _step = 'confirm';
+  int _quantidade = 1;
+  bool _loading = false;
+
+  @override
+  Widget build(BuildContext context) {
+    return Dialog(
+      backgroundColor: Colors.white,
+      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
+      child: Padding(
+        padding: const EdgeInsets.fromLTRB(24, 20, 24, 24),
+        child: AnimatedSwitcher(
+          duration: const Duration(milliseconds: 200),
+          child: _buildStep(),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildStep() {
+    switch (_step) {
+      case 'quantity':   return _buildQuantity();
+      case 'tipo':       return _buildTipo();
+      case 'warning':    return _buildWarning();
+      default:           return _buildConfirm();
+    }
+  }
+
+  // ── Passo 1: Confirmar ────────────────────────────────────────────────────
+
+  Widget _buildConfirm() {
+    return Column(
+      key: const ValueKey('confirm'),
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        const Icon(Icons.warning_amber_rounded, color: AppColors.secondary, size: 48),
+        const SizedBox(height: 12),
+        const Text(
+          'Desativar unidades',
+          textAlign: TextAlign.center,
+          style: TextStyle(
+            color: AppColors.secondary,
+            fontSize: 22,
+            fontWeight: FontWeight.w700,
+          ),
+        ),
+        const SizedBox(height: 4),
+        Text(
+          widget.nomeCategoria,
+          textAlign: TextAlign.center,
+          style: const TextStyle(color: AppColors.greyText, fontSize: 13),
+        ),
+        const SizedBox(height: 12),
+        const Text(
+          'Unidades desativadas não aceitarão novas reservas.',
+          textAlign: TextAlign.center,
+          style: TextStyle(color: AppColors.greyText, fontSize: 14, height: 1.4),
+        ),
+        const SizedBox(height: 24),
+        _buildBotoes(
+          onVoltar: () => Navigator.of(context).pop(),
+          labelVoltar: 'Cancelar',
+          onAvancar: () => setState(() => _step = 'quantity'),
+          labelAvancar: 'Continuar',
+        ),
+      ],
+    );
+  }
+
+  // ── Passo 2: Quantidade ───────────────────────────────────────────────────
+
+  Widget _buildQuantity() {
+    return Column(
+      key: const ValueKey('quantity'),
+      mainAxisSize: MainAxisSize.min,
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        _buildHeader('Quantas unidades?',
+            'Total disponível: ${widget.totalUnidades} unidade${widget.totalUnidades != 1 ? 's' : ''}'),
+        const SizedBox(height: 24),
+        Row(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            Semantics(
+              label: 'Diminuir quantidade',
+              child: IconButton(
+                onPressed: _quantidade > 1 ? () => setState(() => _quantidade--) : null,
+                icon: Icon(Icons.remove_circle_outline,
+                    color: _quantidade > 1 ? AppColors.secondary : AppColors.greyText,
+                    size: 36),
+              ),
+            ),
+            const SizedBox(width: 16),
+            Text(
+              '$_quantidade',
+              style: const TextStyle(
+                color: AppColors.primary,
+                fontSize: 40,
+                fontWeight: FontWeight.w700,
+              ),
+            ),
+            const SizedBox(width: 16),
+            Semantics(
+              label: 'Aumentar quantidade',
+              child: IconButton(
+                onPressed: _quantidade < widget.totalUnidades
+                    ? () => setState(() => _quantidade++)
+                    : null,
+                icon: Icon(Icons.add_circle_outline,
+                    color: _quantidade < widget.totalUnidades
+                        ? AppColors.secondary
+                        : AppColors.greyText,
+                    size: 36),
+              ),
+            ),
+          ],
+        ),
+        if (_quantidade == widget.totalUnidades) ...[
+          const SizedBox(height: 8),
+          Center(
+            child: Text(
+              'Todas as unidades serão desativadas.',
+              style: TextStyle(color: Colors.orange[700], fontSize: 12, fontWeight: FontWeight.w500),
+              textAlign: TextAlign.center,
+            ),
+          ),
+        ],
+        const SizedBox(height: 24),
+        _buildBotoes(
+          onVoltar: _loading ? null : () => setState(() => _step = 'confirm'),
+          labelVoltar: 'Voltar',
+          onAvancar: _loading ? null : () => setState(() => _step = 'tipo'),
+          labelAvancar: 'Continuar',
+        ),
+      ],
+    );
+  }
+
+  // ── Passo 3: Permanente ou Temporário ─────────────────────────────────────
+
+  Widget _buildTipo() {
+    return Column(
+      key: const ValueKey('tipo'),
+      mainAxisSize: MainAxisSize.min,
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        _buildHeader('Como desativar?', '$_quantidade unidade${_quantidade != 1 ? 's' : ''}'),
+        const SizedBox(height: 20),
+        _buildOpcaoTipo(
+          titulo: 'Temporariamente',
+          descricao: 'Unidades ficam indisponíveis. Podem ser reativadas depois.',
+          icone: Icons.pause_circle_outline,
+          onTap: () => _confirmar(permanente: false),
+        ),
+        const SizedBox(height: 10),
+        _buildOpcaoTipo(
+          titulo: 'Permanentemente',
+          descricao: 'Unidades sem reservas são excluídas. Com reservas, ficam indisponíveis até a conclusão.',
+          icone: Icons.delete_outline,
+          cor: Colors.red[600]!,
+          onTap: () {
+            if (widget.temReservaAtiva) {
+              setState(() => _step = 'warning');
+            } else {
+              _confirmar(permanente: true);
+            }
+          },
+        ),
+        const SizedBox(height: 24),
+        OutlinedButton(
+          onPressed: _loading ? null : () => setState(() => _step = 'quantity'),
+          style: OutlinedButton.styleFrom(
+            side: const BorderSide(color: AppColors.primary),
+            shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(11)),
+            minimumSize: const Size(double.infinity, 46),
+          ),
+          child: const Text('Voltar',
+              style: TextStyle(color: AppColors.primary, fontWeight: FontWeight.w600)),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildOpcaoTipo({
+    required String titulo,
+    required String descricao,
+    required IconData icone,
+    required VoidCallback onTap,
+    Color cor = AppColors.primary,
+  }) {
+    return InkWell(
+      onTap: _loading ? null : onTap,
+      borderRadius: BorderRadius.circular(11),
+      child: Container(
+        padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 14),
+        decoration: BoxDecoration(
+          borderRadius: BorderRadius.circular(11),
+          border: Border.all(color: cor.withValues(alpha: 0.3)),
+          color: cor.withValues(alpha: 0.04),
+        ),
+        child: Row(
+          children: [
+            Icon(icone, color: cor, size: 28),
+            const SizedBox(width: 14),
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(titulo,
+                      style: TextStyle(
+                          color: cor, fontSize: 15, fontWeight: FontWeight.w700)),
+                  const SizedBox(height: 2),
+                  Text(descricao,
+                      style: const TextStyle(
+                          color: AppColors.greyText, fontSize: 12, height: 1.3)),
+                ],
+              ),
+            ),
+            Icon(Icons.chevron_right, color: cor.withValues(alpha: 0.5)),
+          ],
+        ),
+      ),
+    );
+  }
+
+  // ── Passo 4: Aviso reserva ativa (permanente + com reserva) ──────────────
+
+  Widget _buildWarning() {
+    final proxima = widget.proximaReservaAtiva;
+    return Column(
+      key: const ValueKey('warning'),
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        Icon(Icons.event_busy, color: Colors.orange[700], size: 44),
+        const SizedBox(height: 12),
+        Text(
+          'Reservas em andamento',
+          textAlign: TextAlign.center,
+          style: TextStyle(
+            color: Colors.orange[700],
+            fontSize: 20,
+            fontWeight: FontWeight.w700,
+          ),
+        ),
+        const SizedBox(height: 8),
+        Text(
+          proxima != null
+              ? 'Próxima reserva ativa: ${_fmtData(proxima)}.\n\nA unidade ficará indisponível até a conclusão ou cancelamento de todas as reservas.'
+              : 'Existem reservas ativas para esta unidade.\n\nEla ficará indisponível até a conclusão ou cancelamento de todas as reservas.',
+          textAlign: TextAlign.center,
+          style: const TextStyle(color: AppColors.greyText, fontSize: 14, height: 1.5),
+        ),
+        const SizedBox(height: 24),
+        _buildBotoes(
+          onVoltar: _loading ? null : () => setState(() => _step = 'tipo'),
+          labelVoltar: 'Voltar',
+          onAvancar: _loading ? null : () => _confirmar(permanente: true),
+          labelAvancar: 'Entendido, continuar',
+          corAvancar: Colors.orange[700]!,
+        ),
+      ],
+    );
+  }
+
+  // ── Helpers visuais ───────────────────────────────────────────────────────
+
+  Widget _buildHeader(String titulo, String subtitulo) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(titulo,
+            style: const TextStyle(
+                color: AppColors.secondary, fontSize: 22, fontWeight: FontWeight.w700)),
+        const SizedBox(height: 2),
+        Text(subtitulo,
+            style: const TextStyle(color: AppColors.greyText, fontSize: 13)),
+      ],
+    );
+  }
+
+  Widget _buildBotoes({
+    VoidCallback? onVoltar,
+    required String labelVoltar,
+    VoidCallback? onAvancar,
+    required String labelAvancar,
+    Color corAvancar = AppColors.secondary,
+  }) {
+    return Row(
+      children: [
+        Expanded(
+          child: OutlinedButton(
+            onPressed: onVoltar,
+            style: OutlinedButton.styleFrom(
+              side: const BorderSide(color: AppColors.primary),
+              shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(11)),
+              padding: const EdgeInsets.symmetric(vertical: 13),
+            ),
+            child: Text(labelVoltar,
+                style: const TextStyle(
+                    color: AppColors.primary, fontWeight: FontWeight.w600)),
+          ),
+        ),
+        const SizedBox(width: 12),
+        Expanded(
+          child: ElevatedButton(
+            onPressed: onAvancar,
+            style: ElevatedButton.styleFrom(
+              backgroundColor: corAvancar,
+              disabledBackgroundColor: Colors.grey[300],
+              shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(11)),
+              padding: const EdgeInsets.symmetric(vertical: 13),
+              elevation: 0,
+            ),
+            child: _loading
+                ? const SizedBox(
+                    height: 18,
+                    width: 18,
+                    child: CircularProgressIndicator(
+                        color: Colors.white, strokeWidth: 2))
+                : Text(labelAvancar,
+                    style: const TextStyle(
+                        color: Colors.white, fontWeight: FontWeight.w700)),
+          ),
+        ),
+      ],
+    );
+  }
+
+  Future<void> _confirmar({required bool permanente}) async {
+    setState(() => _loading = true);
+    await widget.onConfirm(_quantidade, permanente: permanente);
+    if (mounted) Navigator.of(context).pop();
+  }
+
+  String _fmtData(DateTime d) =>
+      '${d.day.toString().padLeft(2, '0')}/${d.month.toString().padLeft(2, '0')}/${d.year}';
+}

--- a/Frontend/lib/features/rooms/presentation/widgets/manual_reservation_dialog.dart
+++ b/Frontend/lib/features/rooms/presentation/widgets/manual_reservation_dialog.dart
@@ -1,0 +1,306 @@
+import 'package:flutter/material.dart';
+import '../../../../core/theme/app_colors.dart';
+
+class ManualReservationDialog extends StatefulWidget {
+  final String nomeCategoria;
+  final double? valorBase;
+  final Set<DateTime> diasIndisponiveis;
+  final Future<String?> Function({
+    required DateTime checkin,
+    required DateTime checkout,
+    required double valorTotal,
+  }) onConfirm;
+
+  const ManualReservationDialog({
+    super.key,
+    required this.nomeCategoria,
+    required this.diasIndisponiveis,
+    required this.onConfirm,
+    this.valorBase,
+  });
+
+  @override
+  State<ManualReservationDialog> createState() => _ManualReservationDialogState();
+}
+
+class _ManualReservationDialogState extends State<ManualReservationDialog> {
+  DateTimeRange? _intervalo;
+  bool _loading = false;
+  String? _erro;
+
+  int get _noites {
+    if (_intervalo == null) return 0;
+    return _intervalo!.end.difference(_intervalo!.start).inDays;
+  }
+
+  // valorBase * noites; fallback de 1.0 para satisfazer a constraint CHECK (valor_total > 0)
+  double get _valorTotal =>
+      (_noites > 0 ? (widget.valorBase ?? 1.0) * _noites : 0.0);
+
+  bool _isDiaIndisponivel(DateTime dia) {
+    final d = DateTime(dia.year, dia.month, dia.day);
+    return widget.diasIndisponiveis
+        .any((x) => x.year == d.year && x.month == d.month && x.day == d.day);
+  }
+
+  Future<void> _selecionarIntervalo() async {
+    final result = await showDateRangePicker(
+      context: context,
+      firstDate: DateTime.now(),
+      lastDate: DateTime.now().add(const Duration(days: 365)),
+      currentDate: DateTime.now(),
+      selectableDayPredicate: (day, _s, _e) => !_isDiaIndisponivel(day),
+      helpText: 'Selecionar período de bloqueio',
+      saveText: 'Confirmar',
+      builder: (context, child) {
+        final screenWidth = MediaQuery.of(context).size.width;
+        return Theme(
+          data: Theme.of(context).copyWith(
+            colorScheme: const ColorScheme.light(
+              primary: AppColors.primary,
+              secondary: AppColors.secondary,
+            ),
+            datePickerTheme: DatePickerThemeData(
+              dividerColor: AppColors.primary.withValues(alpha: 0.15),
+            ),
+            dialogTheme: DialogThemeData(
+              insetPadding: EdgeInsets.symmetric(
+                horizontal: screenWidth * 0.10,
+                vertical: 24,
+              ),
+            ),
+          ),
+          child: Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 16),
+            child: child!,
+          ),
+        );
+      },
+    );
+
+    if (result != null) setState(() => _intervalo = result);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Dialog(
+      backgroundColor: Colors.white,
+      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
+      child: Padding(
+        padding: const EdgeInsets.fromLTRB(24, 20, 24, 24),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            // Header
+            Row(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Expanded(
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      const Text(
+                        'Reserva manual',
+                        style: TextStyle(
+                          color: AppColors.secondary,
+                          fontSize: 22,
+                          fontWeight: FontWeight.w700,
+                        ),
+                      ),
+                      const SizedBox(height: 2),
+                      Text(
+                        widget.nomeCategoria,
+                        style: const TextStyle(
+                          color: AppColors.greyText,
+                          fontSize: 13,
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+                IconButton(
+                  onPressed: _loading ? null : () => Navigator.of(context).pop(),
+                  icon: const Icon(Icons.close, color: AppColors.greyText, size: 20),
+                  padding: EdgeInsets.zero,
+                  constraints: const BoxConstraints(),
+                  tooltip: 'Fechar',
+                ),
+              ],
+            ),
+
+            const SizedBox(height: 20),
+
+            // Seletor de período
+            Semantics(
+              label: 'Selecionar período de reserva',
+              child: GestureDetector(
+                onTap: _selecionarIntervalo,
+                child: Container(
+                  width: double.infinity,
+                  padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 14),
+                  decoration: BoxDecoration(
+                    color: Colors.white,
+                    borderRadius: BorderRadius.circular(11),
+                    border: Border.all(
+                      color: _intervalo != null
+                          ? AppColors.primary
+                          : AppColors.primary.withValues(alpha: 0.3),
+                      width: 1.5,
+                    ),
+                  ),
+                  child: Row(
+                    children: [
+                      Icon(
+                        Icons.calendar_today_outlined,
+                        size: 16,
+                        color: _intervalo != null
+                            ? AppColors.primary
+                            : AppColors.primary.withValues(alpha: 0.4),
+                      ),
+                      const SizedBox(width: 12),
+                      Expanded(
+                        child: _intervalo == null
+                            ? const Text(
+                                'Selecionar datas',
+                                style: TextStyle(
+                                  color: AppColors.greyText,
+                                  fontSize: 14,
+                                ),
+                              )
+                            : Column(
+                                crossAxisAlignment: CrossAxisAlignment.start,
+                                children: [
+                                  Text(
+                                    '${_fmtData(_intervalo!.start)}  →  ${_fmtData(_intervalo!.end)}',
+                                    style: const TextStyle(
+                                      color: AppColors.primary,
+                                      fontSize: 14,
+                                      fontWeight: FontWeight.w600,
+                                    ),
+                                  ),
+                                  Text(
+                                    '$_noites noite${_noites != 1 ? 's' : ''}',
+                                    style: const TextStyle(
+                                      color: AppColors.greyText,
+                                      fontSize: 12,
+                                    ),
+                                  ),
+                                ],
+                              ),
+                      ),
+                      Icon(
+                        Icons.chevron_right,
+                        color: AppColors.primary.withValues(alpha: 0.4),
+                        size: 20,
+                      ),
+                    ],
+                  ),
+                ),
+              ),
+            ),
+
+            if (_erro != null) ...[
+              const SizedBox(height: 12),
+              Container(
+                padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 10),
+                decoration: BoxDecoration(
+                  color: Colors.red.withValues(alpha: 0.07),
+                  borderRadius: BorderRadius.circular(8),
+                  border: Border.all(color: Colors.red.withValues(alpha: 0.2)),
+                ),
+                child: Text(
+                  _erro!,
+                  style: TextStyle(color: Colors.red[700], fontSize: 13),
+                ),
+              ),
+            ],
+
+            const SizedBox(height: 24),
+
+            // Botões
+            Row(
+              children: [
+                Expanded(
+                  child: OutlinedButton(
+                    onPressed: _loading ? null : () => Navigator.of(context).pop(),
+                    style: OutlinedButton.styleFrom(
+                      side: const BorderSide(color: AppColors.primary),
+                      shape: RoundedRectangleBorder(
+                          borderRadius: BorderRadius.circular(11)),
+                      padding: const EdgeInsets.symmetric(vertical: 13),
+                    ),
+                    child: const Text(
+                      'Cancelar',
+                      style: TextStyle(color: AppColors.primary, fontWeight: FontWeight.w600),
+                    ),
+                  ),
+                ),
+                const SizedBox(width: 12),
+                Expanded(
+                  child: Semantics(
+                    label: 'Confirmar reserva manual',
+                    child: ElevatedButton(
+                      onPressed: _intervalo != null && !_loading ? _confirmar : null,
+                      style: ElevatedButton.styleFrom(
+                        backgroundColor: AppColors.secondary,
+                        disabledBackgroundColor: Colors.grey[300],
+                        shape: RoundedRectangleBorder(
+                            borderRadius: BorderRadius.circular(11)),
+                        padding: const EdgeInsets.symmetric(vertical: 13),
+                        elevation: 0,
+                      ),
+                      child: _loading
+                          ? const SizedBox(
+                              height: 18,
+                              width: 18,
+                              child: CircularProgressIndicator(
+                                color: Colors.white,
+                                strokeWidth: 2,
+                              ),
+                            )
+                          : const Text(
+                              'Confirmar',
+                              style: TextStyle(
+                                color: Colors.white,
+                                fontWeight: FontWeight.w700,
+                              ),
+                            ),
+                    ),
+                  ),
+                ),
+              ],
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Future<void> _confirmar() async {
+    setState(() {
+      _loading = true;
+      _erro = null;
+    });
+
+    final erro = await widget.onConfirm(
+      checkin: _intervalo!.start,
+      checkout: _intervalo!.end,
+      valorTotal: _valorTotal > 0 ? _valorTotal : 1.0,
+    );
+
+    if (!mounted) return;
+
+    if (erro != null) {
+      setState(() {
+        _loading = false;
+        _erro = erro;
+      });
+    } else {
+      Navigator.of(context).pop(true);
+    }
+  }
+
+  String _fmtData(DateTime d) =>
+      '${d.day.toString().padLeft(2, '0')}/${d.month.toString().padLeft(2, '0')}/${d.year}';
+}

--- a/conductor/__task/P4-E-my-rooms-page.md
+++ b/conductor/__task/P4-E-my-rooms-page.md
@@ -1,0 +1,52 @@
+# P4-E — my_rooms_page - feat/host-room-listing
+
+## Tela
+`lib/features/rooms/presentation/pages/my_rooms_page.dart`
+
+## Prioridade
+**P4 — Listagens (Feature interna)**
+
+## Branch sugerida
+`feat/my-rooms-page-integration`
+
+---
+
+## Estado Atual
+Lista de quartos do anfitrião. Dados mockados.
+
+## O que integrar
+
+- [ ] Ao entrar na tela, fazer `GET /hotel/quartos` para listar os quartos do hotel autenticado
+- [ ] Complementar com `GET /hotel/categorias` para exibir categorias de quartos
+- [ ] Criar `MyRoomsNotifier` (Riverpod) com:
+  - [ ] Lista de quartos
+  - [ ] Loading state
+  - [ ] Método de refresh
+- [ ] Para cada quarto, buscar foto: `GET /uploads/hotels/:hotel_id/rooms/:quarto_id`
+- [ ] Ação de deletar quarto:
+  - [ ] Confirmação de dialog
+  - [ ] `DELETE /hotel/quartos/:id`
+  - [ ] Remover da lista local após sucesso
+- [ ] Navegar para `edit_room_page` (P5-B) ao tocar em editar
+- [ ] Navegar para `add_room_page` (P5-A) pelo FAB/botão de adicionar
+- [ ] Tratar estado vazio (nenhum quarto cadastrado)
+
+---
+
+## Endpoints usados
+
+| Método | Rota                                          | Auth | Descrição               |
+|--------|-----------------------------------------------|------|-------------------------|
+| GET    | `/hotel/quartos`                              | ✅   | Listar quartos do hotel |
+| GET    | `/hotel/categorias`                           | ✅   | Listar categorias       |
+| DELETE | `/hotel/quartos/:id`                          | ✅   | Deletar quarto          |
+| GET    | `/uploads/hotels/:hotel_id/rooms/:quarto_id`  | ❌   | Fotos do quarto         |
+
+---
+
+## Dependências
+- **Requer:** P0, P2-A (login host), P3-B (perfil host carregado com hotel_id)
+
+## Bloqueia
+- P5-A (`add_room_page`)
+- P5-B (`edit_room_page`)

--- a/conductor/features/my-rooms-page.prd.md
+++ b/conductor/features/my-rooms-page.prd.md
@@ -1,0 +1,91 @@
+# PRD — my-rooms-page
+
+## Contexto
+
+A tela `my_rooms_page` (`lib/features/rooms/presentation/pages/my_rooms_page.dart`) é o painel do anfitrião (host) para gerenciar o inventário de quartos do seu hotel. Hoje a tela existe apenas com dados mockados, sem integração com o backend.
+
+Esta feature integra a tela ao backend, habilitando listagem real, remoção parcial de unidades e inserção manual de reservas na agenda (reserva "cega", sem geração de ticket). A tela também serve como porta de entrada para os fluxos `add_room_page` (P5-A) e `edit_room_page` (P5-B).
+
+**Ponto crítico de modelagem:** no backend, cada `Quarto` representa **uma unidade física** com `numero` único. O que agrupa "3 suítes master single" é o campo `categoria_quarto_id` (tipo de quarto). Portanto, a agregação em cards por tipo de quarto é **responsabilidade do frontend** — o `MyRoomsNotifier` deve agrupar a lista de `Quarto` por `categoria_quarto_id` e renderizar 1 card por categoria, com a contagem total de unidades.
+
+## Problema
+
+Hosts precisam gerenciar o inventário de tipos de quartos cadastrados no hotel. A tela deve permitir:
+- Visualizar os tipos de quarto agregados (cada card representa N unidades de uma mesma categoria)
+- Acessar a tela de edição de cada tipo
+- Remover unidades parciais ou totais com dupla confirmação (modal + picker de quantidade)
+- Inserir reservas manualmente na agenda, sem emissão de ticket, assumindo que o hotel possui sistema próprio de gestão interna e precisa lidar com reservas originadas fora do app
+
+A capacidade diária é limitada pelo total de unidades de cada categoria: quando todas as unidades de um tipo estão ocupadas em um dia, esse dia deve aparecer **indisponível** tanto no fluxo do usuário final (`room_details`) quanto no calendário de reserva manual do host. Um dia só é considerado "cheio" se todas as unidades da categoria estão reservadas **naquele dia específico** (sobreposições parciais em datas diferentes não bloqueiam o calendário como um todo).
+
+## Público-alvo
+
+Anfitriões (hosts) autenticados que possuem hotel cadastrado na plataforma e precisam gerenciar o inventário de tipos de quartos, incluindo edição, remoção parcial de unidades e inserção manual de reservas na agenda.
+
+## Requisitos Funcionais
+
+1. Ao abrir a tela, o sistema deve listar todos os quartos do hotel autenticado via `GET /hotel/quartos` e agrupá-los por `categoria_quarto_id` no frontend, exibindo 1 card por categoria.
+2. O sistema deve buscar as categorias via `GET /hotel/categorias` para enriquecer cada card com o nome e a descrição da categoria.
+3. Cada card agregado deve exibir: foto (primeira unidade da categoria), nome da categoria, total de unidades, valor base/médio da diária e descrição resumida.
+4. Para cada categoria, o sistema deve carregar a foto via `GET /uploads/hotels/:hotel_id/rooms/:quarto_id`, usando o `quarto_id` de uma das unidades daquela categoria.
+5. O `MyRoomsNotifier` (Riverpod) deve gerenciar: lista agregada por categoria, loading state, error state e método de refresh (pull-to-refresh).
+6. O fluxo de deletar deve ser: botão "deletar" no card → modal de confirmação "tem certeza?" → seletor de quantidade (min 1, max = total de unidades da categoria) → ao confirmar, frontend dispara **N chamadas** `DELETE /hotel/quartos/:id`, uma para cada unidade escolhida. Se a quantidade escolhida for igual ao total, o tipo de quarto é removido por completo da listagem.
+7. O fluxo de deletar deve tratar falhas parciais: se algumas chamadas `DELETE` falharem, exibir mensagem informando quantas unidades foram removidas e quantas permaneceram, e recarregar a lista.
+8. O fluxo de reserva manual deve ser: botão "reserva manual" no card → abrir calendário com dias marcados como indisponíveis (aqueles em que todas as unidades da categoria estão ocupadas) → host seleciona intervalo de datas → confirma → sistema chama `POST /hotel/reservas` com `canal_origem: "manual"`, `tipo_quarto`, `num_hospedes`, `data_checkin`, `data_checkout` e `valor_total`.
+9. A disponibilidade por dia deve ser computada no frontend a partir de `GET /hotel/reservas` (filtrado por categoria ou por quarto_ids da categoria) e do total de unidades cadastradas, comparando reservas sobrepostas dia a dia.
+10. O usuário deve poder navegar para `edit_room_page` (P5-B) ao tocar em "editar" em um card.
+11. O usuário deve poder navegar para `add_room_page` (P5-A) através de um FAB ou botão global de adicionar.
+12. A tela deve exibir um estado vazio amigável quando o hotel não possuir quartos cadastrados, com CTA para adicionar o primeiro tipo de quarto.
+13. A tela deve oferecer **busca local** por nome da categoria (filtra a lista já carregada, sem nova chamada ao backend).
+14. A tela deve oferecer **filtro por categoria** usando as categorias retornadas em `GET /hotel/categorias` (chips ou dropdown).
+
+## Requisitos Não-Funcionais
+
+- [ ] **Performance:** listagem inicial exibida em menos de 2s após o `hotelId` estar disponível no estado global.
+- [ ] **Segurança:** todas as rotas autenticadas devem enviar o token JWT do host; o backend já aplica `hotelGuard` em `/hotel/quartos` e `/hotel/reservas`.
+- [ ] **Acessibilidade:** botões de editar, deletar e reservar com `semanticLabel` para leitores de tela; estados (loading, erro, vazio) devem ser anunciáveis.
+- [ ] **Responsividade:** layout deve funcionar em diferentes tamanhos de tela mobile (portrait e landscape).
+- [ ] **Gerenciamento de estado:** uso de Riverpod (`MyRoomsNotifier`) para lista agregada, loading, error e refresh, desacoplado da camada de UI.
+- [ ] **Resiliência:** tratar falhas de rede em todas as chamadas com mensagens claras e opção de retry.
+- [ ] **Consistência de estado após delete parcial:** em caso de falhas parciais nas N chamadas `DELETE`, a UI deve refletir o estado real (recarregando via `GET /hotel/quartos`) e comunicar quantas unidades foram efetivamente removidas.
+
+## Critérios de Aceitação
+
+- Dado que o host está autenticado e possui `hotel_id` carregado, quando abrir a `my_rooms_page`, então a lista de tipos de quartos do seu hotel deve ser exibida agregada por categoria.
+- Dado que o hotel não possui quartos cadastrados, quando a tela carregar, então deve ser exibido um estado vazio com CTA para adicionar o primeiro quarto.
+- Dado que o host tocou em "deletar" em um card, quando confirmar no modal e escolher uma quantidade menor que o total, então apenas N unidades devem ser removidas e o card deve continuar visível com `total - N` unidades.
+- Dado que o host tocou em "deletar" e escolheu o valor máximo (igual ao total de unidades), quando confirmar, então todas as unidades devem ser removidas e o card deve sumir da listagem.
+- Dado que o host tocou em "deletar" e cancelou o modal ou o picker, quando fechar, então nenhuma requisição `DELETE` deve ser disparada.
+- Dado que ocorreu falha em parte das N chamadas `DELETE`, quando o fluxo terminar, então a UI deve exibir mensagem indicando quantas unidades foram removidas com sucesso e quantas falharam, e recarregar a lista.
+- Dado que o host tocou em "reserva manual" em um card, quando o calendário abrir, então os dias em que todas as unidades daquela categoria estão ocupadas devem aparecer indisponíveis.
+- Dado que o host selecionou um intervalo válido no calendário de reserva manual, quando confirmar, então a reserva deve ser registrada via `POST /hotel/reservas` com `canal_origem: "manual"` e o intervalo deve passar a bloquear o calendário em chamadas subsequentes.
+- Dado que uma categoria tem 3 unidades e todas estão reservadas em um dia X, quando o usuário final abrir `room_details` e testar disponibilidade para o dia X, então deve receber "indisponível" com a data de próxima disponibilidade.
+- Dado que uma categoria tem 3 unidades, 2 reservadas de 23/04 a 29/04 e 3 reservadas de 29/04 a 31/04, quando o calendário de reserva manual for aberto, então **apenas o dia 29/04** deve aparecer indisponível (dia em que todas as 3 unidades estão simultaneamente ocupadas).
+- Dado que o host tocou em "editar" em um card, quando a ação for executada, então deve navegar para `edit_room_page` com a categoria/quartos selecionados.
+- Dado que o host tocou no FAB global de adicionar, quando a ação for executada, então deve navegar para `add_room_page`.
+- Dado que a requisição `GET /hotel/quartos` falhar, quando a tela carregar, então deve ser exibida mensagem de erro com botão "tentar novamente".
+- Dado que o host puxou a tela para baixo, quando o refresh for disparado, então a lista deve ser recarregada do backend.
+- Dado que o host digitou texto na busca, quando houver correspondência parcial com o nome de alguma categoria, então apenas os cards correspondentes devem permanecer visíveis.
+- Dado que o host selecionou uma categoria no filtro, quando a seleção for aplicada, então apenas os cards daquela categoria devem permanecer visíveis.
+
+## Dependências de Backend
+
+Para que o fluxo de reserva manual funcione como "reserva cega" (sem identificação de hóspede), é necessário o seguinte ajuste no backend:
+
+- [ ] **Ajustar `Reserva.validateWalkin`** (`Backend/src/entities/Reserva.ts`) para aceitar `canal_origem: "manual"` dispensando os campos de identificação do hóspede (`user_id`, `nome_hospede`, `cpf_hospede`, `telefone_contato`). Reservas marcadas como manuais servem apenas para bloquear a agenda, pois o hotel possui sistema próprio de gestão interna.
+
+**Backlog técnico futuro (não bloqueia esta feature):**
+- [ ] Criar endpoint `GET /hotel/categorias/:id/disponibilidade?from=X&to=Y` que retorne dias lotados por categoria, evitando o processamento pesado no frontend em hotéis com muitas reservas.
+- [ ] Avaliar endpoint de remoção em lote `DELETE /hotel/categorias/:cat_id/quartos?quantidade=N` caso a estratégia de N chamadas revele problemas de consistência em produção.
+
+## Fora de Escopo
+
+- Implementação das telas `add_room_page` (P5-A) e `edit_room_page` (P5-B).
+- Upload, alteração ou remoção de fotos dos quartos nesta tela.
+- Geração de ticket ou comprovante de reserva — a reserva manual apenas altera a agenda.
+- Seleção de unidade específica dentro da categoria ao criar reserva manual (o gerenciamento interno de "qual unidade vai para qual hóspede" é responsabilidade do sistema interno do hotel).
+- Preenchimento de dados de hóspede na reserva manual (reserva cega).
+- Relatórios de ocupação, analytics ou dashboards.
+- Filtros avançados (faixa de preço, comodidades, datas). Apenas busca por nome e filtro por categoria.
+- Endpoint dedicado de disponibilidade (vai para backlog técnico).
+- Reordenação manual dos cards.

--- a/conductor/plan.md
+++ b/conductor/plan.md
@@ -103,6 +103,22 @@
 
 ---
 
+## Fase P4-E — My Rooms Page [EM ANDAMENTO]
+
+> Plan: `plans/my-rooms-page.plan.md`
+> Spec: `specs/my-rooms-page.spec.md`
+> PRD: `features/my-rooms-page.prd.md`
+
+- [ ] Ajustar backend: enum `CanalOrigem` + `Reserva.validateWalkin` aceitar `canal_origem: "manual"` sem identificação de hóspede
+- [x] Criar modelos: `QuartoModel`, `RoomCategoryCardModel`, `ReservaHotelModel` (reutiliza `CategoriaHotelModel`)
+- [x] Criar `AvailabilityCalculator` (utility puro) — testes unitários pendentes
+- [x] Criar `MyRoomsState` + `MyRoomsNotifier` com load paralelo, delete via N chamadas `DELETE` e reserva manual
+- [x] Criar `DeleteRoomDialog` (modal + quantity picker) e `ManualReservationDialog` (calendário de range com dias indisponíveis)
+- [x] Atualizar `my_rooms_page.dart` (remover mock, consumir notifier, busca/filtro, estados, navegação para add/edit room)
+- [ ] Validar fluxos: listagem, delete parcial/total, reserva manual, disponibilidade agregada, busca e filtro
+
+---
+
 ## Fase 3 — Sistema de Reservas [PENDENTE]
 
 > Spec: `specs/reservas.spec.md`

--- a/conductor/plans/my-rooms-page.plan.md
+++ b/conductor/plans/my-rooms-page.plan.md
@@ -1,0 +1,133 @@
+# Plan — my-rooms-page
+
+> Derivado de: conductor/specs/my-rooms-page.spec.md
+> Status geral: [EM ANDAMENTO] — Frontend concluído, Backend pendente (PR separada), Validação parcial
+
+**Dependências:** Requer P0 (infra-http-client), P2-A (login host) e P3-B (perfil host com `hotel_id`) já concluídos.
+**Bloqueia:** P5-A (add_room_page) e P5-B (edit_room_page).
+
+---
+
+## Setup & Infraestrutura [CONCLUÍDO]
+
+- [x] Auditar enum `CanalOrigem` em `Backend/src/entities/Reserva.ts` — confirmado: `'MANUAL'` ausente, necessidade registrada no bloco Backend
+- [x] Auditar valores do enum `ReservaStatus` em `Backend/src/entities/Reserva.ts` — status ativos: `SOLICITADA`, `AGUARDANDO_PAGAMENTO`, `APROVADA`; ignorados: `CANCELADA`, `CONCLUIDA`
+- [x] Verificar no `Frontend/pubspec.yaml` — sem lib externa necessária; utilizado `showDateRangePicker` nativo do Flutter (v3.41.7) com `SelectableDayForRangePredicate`
+
+---
+
+## Backend [PENDENTE] — próximo passo, não executar agora
+
+> ⚠️ Este bloco documenta as alterações de backend necessárias para o fluxo de reserva manual. Será feito em PR próprio, em paralelo com a implementação do frontend.
+
+- [ ] Adicionar valor `"manual"` ao enum `CanalOrigem` em `Backend/src/entities/Reserva.ts` caso ainda não exista
+- [ ] Modificar `Reserva.validateWalkin` em `Backend/src/entities/Reserva.ts` para dispensar a obrigatoriedade de identificação do hóspede (`user_id` / `nome_hospede` + `cpf_hospede` ou `telefone_contato`) quando `canal_origem === "manual"`. Demais validações (datas, `num_hospedes`, `valor_total`) permanecem ativas
+- [ ] Ajustar `createReservaWalkin` em `Backend/src/services/reserva.service.ts` para:
+  - Persistir `canal_origem = "manual"` quando recebido no input
+  - Não disparar efeitos colaterais dependentes de hóspede (notificações de confirmação, vínculos de fidelidade, etc.) em reservas manuais
+- [ ] Adicionar testes unitários cobrindo:
+  - Walk-in tradicional continua exigindo identificação do hóspede (regressão)
+  - Walk-in com `canal_origem: "manual"` aceita criação sem identificação
+  - Reserva manual não aciona notificações/efeitos dependentes de hóspede
+- [ ] Abrir PR no backend com as alterações acima
+
+---
+
+## Frontend [CONCLUÍDO]
+
+### Modelos de Domínio
+
+- [x] Criar `QuartoModel` + `QuartoItem` em `lib/features/rooms/domain/models/quarto.dart`
+- [x] Criar `CategoriaQuartoModel` — reutilizado `CategoriaHotelModel` de `hotel_details.dart` (estrutura compatível com `GET /:hotel_id/categorias`)
+- [x] Criar `RoomCategoryCardModel` em `lib/features/rooms/domain/models/room_category_card.dart`
+- [x] Criar `ReservaHotelModel` em `lib/features/rooms/domain/models/reserva_hotel.dart` com constante `kStatusAtivos`
+
+### Domínio / Lógica
+
+- [x] Criar `AvailabilityCalculator` em `lib/features/rooms/domain/services/availability_calculator.dart` — função pura `computeDiasIndisponiveis(reservas, quartoIds, totalUnidades)` retornando `Set<DateTime>`
+- [ ] Cobrir `AvailabilityCalculator` com testes unitários:
+  - Sem reservas → conjunto vazio
+  - Reservas parciais (não atingem total de unidades) → conjunto vazio
+  - Dia com todas as unidades ocupadas → dia no conjunto
+  - Cenário 23/04–29/04 (2 unidades) + 29/04–31/04 (3 unidades) com total 3 → apenas 29/04 no conjunto
+  - Reservas com status cancelada/expirada ignoradas
+
+### State (Riverpod)
+
+- [x] Criar `MyRoomsState` em `lib/features/rooms/presentation/notifiers/my_rooms_state.dart` com getter `cardsFiltrados` embutido
+- [x] Criar `MyRoomsNotifier` em `lib/features/rooms/presentation/notifiers/my_rooms_notifier.dart` via `NotifierProvider`
+- [x] `myRoomsNotifierProvider` criado como `NotifierProvider<MyRoomsNotifier, MyRoomsState>`
+
+### Widgets
+
+- [x] Criar `DeleteRoomDialog` — fluxo 4 passos (confirmação → quantity → permanente/temporário → aviso reserva ativa), visual alinhado ao padrão da app (branco, laranja, sem ícone externo)
+- [x] Criar `ManualReservationDialog` — `showDateRangePicker` nativo com `SelectableDayForRangePredicate` bloqueando dias lotados; campos de hóspedes e valor removidos (calculado internamente); visual alinhado (fundo branco, título laranja, borda azul no seletor)
+
+### Página
+
+- [x] Converter `my_rooms_page.dart` para `ConsumerStatefulWidget`, remover mock
+- [x] Consumir `ref.watch(myRoomsNotifierProvider)`, renderizar `state.cardsFiltrados`
+- [x] Estados: loading, erro (com retry), vazio (com CTA), filtro sem resultado
+- [x] Busca local por nome da categoria
+- [x] Filtro `Todos / Disponíveis / Indisponíveis` via `FiltroDisponibilidade` enum
+- [x] Card ativo: foto, nome, total de unidades, valor, descrição; ações "Reserva manual" + "Desativar"
+- [x] Card inativo: foto 45% opacidade, badge "Desativado", próxima reserva ativa ou "Sem reservas ativas"; ações "Reativar" + "Remover"
+- [x] Wire "editar" → `/edit_room/:id`, FAB → `/add_room`
+- [x] Pull-to-refresh com `RefreshIndicator`; snackbars de resultado
+
+### Ajustes pós-implementação (UI + comportamento)
+
+- [x] Reduzir altura do card (160 → 120px), foto (130 → 110px), aumentar fonte do nome categoria (15 → 17px)
+- [x] `VerticalDivider` entre botões de ação corrigido com `IntrinsicHeight`
+- [x] Remover filtro por categoria (decisão de produto: busca por nome é suficiente)
+- [x] `AvailabilityCalculator` corrigido para contar reservas BALCAO sem `quarto_id` via `tipo_quarto` (case-insensitive)
+- [x] Backend — `Reserva.validateWalkin`: identificação do hóspede tornada opcional para walk-ins de balcão sem hóspede (bloqueio de agenda)
+- [x] Backend — `init_tenant.sql`: constraint `chk_hospede_identificado` atualizada para dispensar identificação quando `canal_origem = 'BALCAO'`
+- [x] Backend — constraint `hotel_99999999000199` (schema de teste) atualizada via `ALTER TABLE`
+- [x] Fluxo de desativação substituiu o de remoção: permanente deleta se sem reservas, marca `disponivel=false` se com reservas; temporário sempre marca `disponivel=false`
+- [x] Verificação de bloqueio de exclusão em card inativo: exclusão bloqueada se `reservasAtivas > quartosAtivos`
+- [x] Seed `seed.my-rooms-page.ts` criado com 5 cenários de teste; corrigido `updateConfiguracaoHotel` + criação de `hospede` antes das reservas
+- [x] Notifier: load usa `_fetchHotelId` via `GET /hotel/me` (autossuficiente, sem depender de `hostProfileProvider`); trigger migrado para `Future.microtask`
+
+---
+
+## Validação [EM ANDAMENTO]
+
+- [x] **Listagem inicial:** cards agrupados por categoria com foto, nome, total de unidades e valor base renderizados corretamente
+- [ ] **Estado vazio:** com hotel sem quartos cadastrados, verificar que CTA "Adicionar primeiro quarto" é exibido
+- [x] **Delete parcial:** Suíte Família (4 unidades) → deletar 2 → card permanece com 2 unidades (C4 ✅)
+- [x] **Delete total:** Quarto Single Business (1 unidade) → deletar 1 → card desaparece da lista (C3 ✅)
+- [ ] **Cancelar delete:** no modal de confirmação e no quantity picker, cancelar não dispara nenhuma requisição
+- [ ] **Falha parcial no delete:** simular erro em 1 das N chamadas → snackbar exibe contagem correta e lista é recarregada
+- [x] **Reserva manual — happy path:** criar reserva → dia passa a aparecer indisponível no calendário após reload (C2 ✅)
+- [x] **Cenário chave de disponibilidade:** Suíte Master com 2+3 reservas sobrepostas → dias lotados bloqueados no calendário (C1 ✅)
+- [x] **BALCAO sem quarto_id conta para disponibilidade:** após 2 reservas manuais no Duplo Premium, calendário bloqueia os dias (fix AvailabilityCalculator + tipo_quarto ✅)
+- [ ] **Disponibilidade no `room_details`:** com todas as unidades de uma categoria ocupadas em um dia X, usuário final vê "indisponível"
+- [x] **Busca local:** buscar "master", "duplo", "single", "família" filtra corretamente (C5 ✅)
+- [x] **Filtro Disponíveis/Indisponíveis:** chips `Todos / Disponíveis / Indisponíveis` funcionando (substitui filtro por categoria)
+- [x] **Card inativo:** visual diferenciado (fundo cinza, foto 45% opacidade, badge, info de próxima reserva)
+- [x] **Desativar temporário:** unidades marcadas como `disponivel=false`, aparecem no card inativo
+- [x] **Desativar permanente sem reserva:** unidades deletadas imediatamente
+- [x] **Desativar permanente com reserva:** unidades marcadas como `disponivel=false` com aviso da próxima reserva no dialog
+- [x] **Reativar:** unidades voltam a `disponivel=true` e somem do card inativo
+- [x] **Remover do card inativo sem reservas bloqueantes:** DELETE imediato
+- [x] **Remover do card inativo bloqueado:** dialog "Exclusão bloqueada" quando reservasAtivas > quartosAtivos
+- [ ] **Pull-to-refresh:** puxar a tela recarrega a lista do backend
+- [ ] **Erro de rede inicial:** desligar backend → mensagem de erro com botão "Tentar novamente"
+- [ ] **Navegação para editar:** tocar em "editar" navega para `edit_room_page`
+- [ ] **Navegação para adicionar:** tocar no FAB navega para `add_room_page`
+- [ ] **Acessibilidade:** `semanticLabel` nos botões verificados em leitor de tela
+- [ ] **Responsividade:** layout em portrait e landscape
+
+---
+
+## Sincronização com o Plan Geral
+
+Conforme `conductor/prompts/prompt-plan-generator.md`, ao atualizar checkboxes neste arquivo:
+
+1. Atualize o status de cada seção (`[PENDENTE]` → `[EM ANDAMENTO]` → `[CONCLUÍDO]`) conforme a regra: todas `[ ]` → PENDENTE, algumas `[x]` → EM ANDAMENTO, todas `[x]` → CONCLUÍDO.
+2. Atualize o **Status geral** no topo quando todas as seções estiverem `[CONCLUÍDO]`.
+3. Sincronize com `conductor/plan.md`:
+   - Localize a fase **P4-E — My Rooms Page**
+   - Reflita o status do header e marque as tasks resumidas como `[x]` à medida que as tasks detalhadas aqui forem concluídas
+   - Quando o Status geral deste plan for `[CONCLUÍDO]`, marque a fase em `plan.md` como `[CONCLUÍDO]` e garanta que todos os checkboxes resumidos estejam `[x]`

--- a/conductor/specs/my-rooms-page.spec.md
+++ b/conductor/specs/my-rooms-page.spec.md
@@ -1,0 +1,171 @@
+# Spec — my-rooms-page
+
+## Referência
+- **PRD:** conductor/features/my-rooms-page.prd.md
+
+## Abordagem Técnica
+
+Criar `MyRoomsNotifier` + `MyRoomsState` seguindo o padrão Riverpod já estabelecido no projeto (mesmo estilo do `HotelDetailsNotifier`). Ao montar a tela, disparar em paralelo via `Future.wait` (com tratamento individual de exceções): `GET /hotel/quartos`, `GET /hotel/categorias` e `GET /hotel/reservas` (filtrado por janela de datas relevante).
+
+No cliente, agregar os `Quarto[]` por `categoria_quarto_id` gerando `RoomCategoryCardModel[]`, anexar nome/descrição da categoria e calcular a ocupação por dia a partir das reservas ativas via um utilitário puro `AvailabilityCalculator` (testável isoladamente).
+
+Os fluxos de escrita ficam em dialogs dedicados:
+- **Delete:** `DeleteRoomDialog` coleta a quantidade N e dispara N chamadas `DELETE /hotel/quartos/:id` em paralelo via `Future.wait(eagerError: false)`; após execução, recarrega a lista e comunica sucessos/falhas parciais.
+- **Reserva manual:** `ManualReservationDialog` exibe calendário de range com os dias lotados da categoria já marcados como indisponíveis; ao confirmar, chama `POST /hotel/reservas` com `canal_origem: "manual"`.
+
+O backend recebe um ajuste mínimo em `Reserva.validateWalkin` para aceitar reservas manuais sem identificação de hóspede, preservando a validação estrita para walk-ins de balcão tradicionais.
+
+## Componentes Afetados
+
+### Backend
+- **Modificado:** enum `CanalOrigem` (`Backend/src/entities/Reserva.ts`) — adicionar valor `"manual"` caso ainda não exista.
+- **Modificado:** `Reserva.validateWalkin` (`Backend/src/entities/Reserva.ts`) — quando `canal_origem === "manual"`, dispensar a obrigatoriedade de identificação do hóspede (`user_id` / `nome_hospede` + `cpf_hospede` ou `telefone_contato`). Demais validações (datas, `num_hospedes`, `valor_total`) permanecem ativas.
+- **Modificado:** `createReservaWalkin` (`Backend/src/services/reserva.service.ts`) — garantir que reservas manuais não disparem efeitos colaterais dependentes de hóspede (ex: notificações de confirmação, vínculo com fidelidade). Persistir `canal_origem = "manual"` no registro.
+- **Verificação:** schema do banco já suporta (`nome_hospede`, `cpf_hospede`, `telefone_contato` são nullable). Não há migration necessária.
+- Nenhum endpoint novo. Todos os demais fluxos da feature consomem endpoints já existentes.
+
+### Frontend
+- **Novo:** `MyRoomsNotifier` (`lib/features/rooms/presentation/notifiers/my_rooms_notifier.dart`)
+- **Novo:** `MyRoomsState` (`lib/features/rooms/presentation/notifiers/my_rooms_state.dart`)
+- **Novo:** `QuartoModel` (`lib/features/rooms/domain/models/quarto.dart`) — uma unidade física
+- **Novo:** `CategoriaQuartoModel` (`lib/features/rooms/domain/models/categoria_quarto.dart`) — reavaliar reuso do `CategoriaModel` já existente em `hotel_details`; se divergir, criar dedicado
+- **Novo:** `RoomCategoryCardModel` (`lib/features/rooms/domain/models/room_category_card.dart`) — modelo agregado que alimenta cada card
+- **Novo:** `ReservaHotelModel` (`lib/features/rooms/domain/models/reserva_hotel.dart`) — subset dos campos necessários para cálculo de disponibilidade
+- **Novo:** `AvailabilityCalculator` (`lib/features/rooms/domain/services/availability_calculator.dart`) — utilitário puro que recebe `List<ReservaHotelModel>` + `totalUnidades` e retorna `Set<DateTime>` de dias indisponíveis
+- **Novo:** `DeleteRoomDialog` (`lib/features/rooms/presentation/widgets/delete_room_dialog.dart`) — confirmação + quantity picker (min 1, max = total de unidades)
+- **Novo:** `ManualReservationDialog` (`lib/features/rooms/presentation/widgets/manual_reservation_dialog.dart`) — calendário de range com dias lotados marcados como indisponíveis
+- **Modificado:** `my_rooms_page.dart` (`lib/features/rooms/presentation/pages/my_rooms_page.dart`) — remover mock, consumir `myRoomsNotifierProvider`, plugar busca local + filtro por categoria, wire dos dialogs, tratar estados (loading, error, empty), FAB para `add_room_page`, tap em editar navega para `edit_room_page`
+
+## Decisões de Arquitetura
+
+| Decisão | Justificativa |
+|---------|---------------|
+| Agregação por categoria no frontend | Backend entrega `Quarto[]` com `categoria_quarto_id`; agregar no cliente evita endpoint duplicado e é computacionalmente barato |
+| N chamadas `DELETE` em paralelo (`Future.wait(eagerError: false)`) | Reusa endpoint já auditado com `hotelGuard`; permite coletar sucessos e falhas individuais |
+| Recarregar lista do backend após delete | Fonte da verdade é o servidor; evita divergência de estado em falhas parciais |
+| Disponibilidade computada client-side via `AvailabilityCalculator` puro | Nenhum endpoint dedicado existe hoje; classe pura é testável e trivialmente substituível pelo endpoint do backlog no futuro |
+| Ajuste em `validateWalkin` em vez de novo endpoint de bloqueio | Reserva manual é semanticamente um walk-in; manter um único ponto canônico para reservas evita divergência de lógica |
+| `canal_origem: "manual"` como marcador no banco | Distingue bloqueios de agenda de walk-ins reais; útil para relatórios e filtros futuros |
+| Dialogs em arquivos dedicados (não inline na page) | Delete e reserva manual têm estado e regras próprias; separar melhora testabilidade e legibilidade |
+| `Future.wait` com tratamento individual no load inicial | Mesma estratégia do `HotelDetailsNotifier`; falha em reservas não impede renderização de quartos/categorias |
+| Busca e filtro locais (sem nova request) | Lista agregada é pequena; processamento client-side é instantâneo e reduz carga no backend |
+| Filtrar `GET /hotel/reservas` por janela de datas (ex: próximos 6 meses) | Evita baixar histórico irrelevante para cálculo de disponibilidade atual |
+
+## Contratos de API
+
+| Método | Rota | Body | Response | Status |
+|--------|------|------|----------|--------|
+| GET | `/hotel/quartos` | — | `{ data: Quarto[] }` | existente |
+| GET | `/hotel/categorias` | — | `{ data: Categoria[] }` | existente |
+| GET | `/hotel/reservas?data_checkin_from=&data_checkout_to=` | — | `{ data: Reserva[] }` | existente |
+| GET | `/uploads/hotels/:hotel_id/rooms/:quarto_id` | — | URL/binary da foto | existente |
+| DELETE | `/hotel/quartos/:id` | — | 204 | existente (invocado N vezes em paralelo) |
+| POST | `/hotel/reservas` | `{ canal_origem: "manual", tipo_quarto, num_hospedes, data_checkin, data_checkout, valor_total }` | `{ data: Reserva }` | **modificado** — aceitar sem identificação de hóspede quando `canal_origem === "manual"` |
+
+**Nota:** Todos os endpoints `hotel/*` exigem `hotelGuard` (JWT + `hotel_id` no contexto).
+
+## Modelos de Dados
+
+```
+QuartoModel {
+  id: int
+  numero: String
+  categoriaQuartoId: int
+  descricao: String?
+  valorDiaria: double?
+  disponivel: bool
+  itens: List<QuartoItem>
+}
+
+QuartoItem {
+  catalogoId: int
+  nome: String
+  categoria: String
+  quantidade: int
+}
+
+CategoriaQuartoModel {
+  id: int
+  nome: String
+  descricao: String?
+  capacidade: int?
+  precoBase: double?
+}
+
+RoomCategoryCardModel {
+  categoriaId: int
+  nomeCategoria: String
+  descricao: String?
+  totalUnidades: int
+  quartoIds: List<int>      // usados no delete (N chamadas) e no cálculo de disponibilidade
+  fotoUrl: String?
+  valorBase: double?
+}
+
+ReservaHotelModel {
+  id: int
+  quartoId: int?
+  tipoQuarto: String?
+  categoriaQuartoId: int?   // derivado via join local com QuartoModel.categoriaQuartoId
+  dataCheckin: DateTime
+  dataCheckout: DateTime
+  status: String             // filtrar apenas status ativos para ocupação
+}
+
+MyRoomsState {
+  cards: List<RoomCategoryCardModel>
+  categorias: List<CategoriaQuartoModel>
+  reservas: List<ReservaHotelModel>
+  diasIndisponiveisPorCategoria: Map<int, Set<DateTime>>
+  busca: String
+  categoriaSelecionada: int?
+  loading: bool
+  error: String?
+  deleteInProgress: bool
+  reservaInProgress: bool
+}
+```
+
+**Contrato do `AvailabilityCalculator`:**
+```
+Set<DateTime> computeDiasIndisponiveis(
+  List<ReservaHotelModel> reservasAtivas,
+  int totalUnidades,
+)
+```
+Para cada dia no intervalo agregado das reservas, contar sobreposições (checkin inclusivo, checkout exclusivo). Um dia `D` é indisponível quando `contagemReservasAtivasEm(D) >= totalUnidades`.
+
+## Dependências
+
+**Bibliotecas:**
+- [x] `dio ^5.7.0` — cliente HTTP (já presente)
+- [x] `flutter_riverpod ^3.3.1` — state management (já presente)
+- [x] `go_router ^17.2.1` — navegação (já presente)
+- [ ] `table_calendar` (ou equivalente já adotado) — calendário com seleção de range e marcação de dias indisponíveis. Verificar se já há lib utilizada em `room_details_page` e reusar.
+
+**Serviços externos:** nenhum.
+
+**Outras features:**
+- [x] P0 — `dioProvider` configurado com interceptor de autenticação
+- [x] P2-A — login host (JWT)
+- [x] P3-B — perfil host com `hotel_id` carregado no estado global
+- [ ] **Backend:** ajuste em `Reserva.validateWalkin` para aceitar reserva manual sem identificação (dependência interna; abrir PR em paralelo)
+
+**Bloqueia:**
+- P5-A (`add_room_page`) — navegação sai desta tela
+- P5-B (`edit_room_page`) — navegação sai desta tela
+
+## Riscos Técnicos
+
+| Risco | Mitigação |
+|-------|-----------|
+| Delete parcial deixa estado inconsistente entre UI e backend | `Future.wait(eagerError: false)`; após execução recarregar via `GET /hotel/quartos` e exibir snackbar com `M/N removidas com sucesso` |
+| `GET /hotel/reservas` pode trazer volume alto em hotéis com muita operação | Filtrar por janela de datas relevante (ex: próximos 6 meses) via query params; avaliar paginação se o backend suportar |
+| Cálculo de disponibilidade client-side fica lento com >500 reservas | Extrair `AvailabilityCalculator` puro e memoizar por categoria; monitorar em produção; acelerar endpoint do backlog se persistir |
+| Modificação em `validateWalkin` quebra walk-ins de balcão existentes | Manter exigência de identificação quando `canal_origem !== "manual"`; cobrir ambos os caminhos com testes antes de mergear |
+| Reservas canceladas ou expiradas contabilizando ocupação | Filtrar por status ativos (`confirmada`, `checkin_realizado`, etc.) dentro do `AvailabilityCalculator`; confirmar a lista válida no enum `ReservaStatus` antes de fixar |
+| Foto via `quarto_id` retorna 404 se o primeiro `quarto_id` não tiver upload | Fallback: tentar próxima unidade da categoria; se todas falharem, exibir placeholder |
+| `table_calendar` ou similar não suporta nativamente "faixas indisponíveis" | Usar `holidayPredicate`/`disabledDayPredicate` para marcar dias do `Set<DateTime>` retornado pelo `AvailabilityCalculator` |
+| Reserva manual enviada com `tipo_quarto` textual pode divergir de `categoria.nome` | Padronizar: enviar `tipo_quarto = categoria.nome` (exato) ou, preferencialmente, enviar `quarto_id` da primeira unidade da categoria |
+| Concorrência: host deleta unidade enquanto outra reserva está sendo criada na mesma categoria | Tratar erros 409/404 no `DELETE` como "já removido" e seguir o fluxo; recarregar no final garante consistência |
+| Enum `CanalOrigem` pode não conter `"manual"` ainda | Auditar o enum antes de iniciar; adicionar o valor caso ausente (parte do ajuste de backend) |


### PR DESCRIPTION
## O que foi feito

Integra a `my_rooms_page` ao backend com listagem real de quartos agregada por categoria, fluxo completo de reserva manual com calendário de disponibilidade, desativação/reativação de unidades com verificação de reservas ativas, card inativo com visual diferenciado e filtro Disponíveis/Indisponíveis.
Plan: `conductor/plans/my-rooms-page.plan.md`

## Arquivos criados

**Frontend — Modelos**
- `Frontend/lib/features/rooms/domain/models/quarto.dart` — `QuartoModel` + `QuartoItemModel` mapeando resposta de `GET /hotel/quartos`
- `Frontend/lib/features/rooms/domain/models/room_category_card.dart` — modelo agregado por categoria (disponível + inativo), com `proximaReservaAtiva`
- `Frontend/lib/features/rooms/domain/models/reserva_hotel.dart` — `ReservaHotelModel` com constante `kStatusAtivos`

**Frontend — Lógica**
- `Frontend/lib/features/rooms/domain/services/availability_calculator.dart` — `computeDiasIndisponiveis()`: conta reservas com `quarto_id` físico E reservas BALCAO por `tipo_quarto` (sem `quarto_id`)

**Frontend — State**
- `Frontend/lib/features/rooms/presentation/notifiers/my_rooms_state.dart` — `MyRoomsState` + `FiltroDisponibilidade` enum + getter `cardsFiltrados`
- `Frontend/lib/features/rooms/presentation/notifiers/my_rooms_notifier.dart` — `MyRoomsNotifier` com load paralelo, `deativarUnidades`, `reativarUnidades`, `excluirUnidadesInativas`, `verificarBloqueioExclusao`, `criarReservaManual`

**Frontend — Widgets**
- `Frontend/lib/features/rooms/presentation/widgets/delete_room_dialog.dart` — dialog 4 passos: confirmação → quantity picker → permanente/temporário → aviso de reserva ativa
- `Frontend/lib/features/rooms/presentation/widgets/manual_reservation_dialog.dart` — seletor de range com dias bloqueados, valor calculado automaticamente, visual alinhado ao padrão da app

**Backend**
- `Backend/src/database/seeds/seed.my-rooms-page.ts` — seed com 5 cenários de teste (`hotel: myrooms@teste.com / Seed@2026`)

**Conductor**
- `conductor/__task/P4-E-my-rooms-page.md`, `conductor/features/my-rooms-page.prd.md`, `conductor/specs/my-rooms-page.spec.md`, `conductor/plans/my-rooms-page.plan.md`

## Arquivos modificados

- `Frontend/lib/features/rooms/presentation/pages/my_rooms_page.dart`
  - Convertido de `StatefulWidget` + mock para `ConsumerStatefulWidget` integrado ao `MyRoomsNotifier`
  - Card ativo: foto, nome, unidades, valor; ações "Reserva manual" + "Desativar"
  - Card inativo: foto 45% opacidade, badge "Desativado", info de próxima reserva; ações "Reativar" + "Remover"
  - Filtro `Todos / Disponíveis / Indisponíveis`; busca local por nome
  - Pull-to-refresh, estados de loading/erro/vazio

- `Backend/src/entities/Reserva.ts`
  - `validateWalkin`: identificação do hóspede agora opcional para walk-ins BALCAO sem hóspede (bloqueio de agenda)
  - Validação de consistência mantida: se informar `nome_hospede`, exige CPF ou telefone

- `Backend/database/scripts/init_tenant.sql`
  - Constraint `chk_hospede_identificado` atualizada: dispensa identificação quando `canal_origem = 'BALCAO'`

- `Backend/src/database/seeds/index.ts` — registra novo seed `myRoomsPage`
- `Backend/package.json` — adiciona script `db:seed:my-rooms-page`
- `conductor/plan.md` — adiciona fase P4-E com status EM ANDAMENTO

## Dependências desta PR

- Requer: P0 (infra-http-client), P2-A (login host), P3-B (perfil host com `hotel_id`)
- Bloqueia: P5-A (`add_room_page`), P5-B (`edit_room_page`)
- ⚠️ Backend separado pendente: testes unitários de `validateWalkin` (documentado no plan)

## Checklist de validação

- [x] Listagem inicial: cards agrupados por categoria com foto, nome, total de unidades e valor base
- [x] Busca local por nome da categoria filtra corretamente
- [x] Filtro Disponíveis/Indisponíveis via chips
- [x] Card inativo: visual diferenciado, info de próxima reserva ativa
- [x] Reserva manual happy path: dia passa a aparecer bloqueado no calendário (incluindo reservas BALCAO sem `quarto_id`)
- [x] Cenário chave de disponibilidade: sobreposição parcial → apenas dias com 100% das unidades ocupadas ficam bloqueados
- [x] Desativar temporário: unidades marcadas como `disponivel=false`, aparecem no card inativo
- [x] Desativar permanente sem reserva: unidades deletadas imediatamente
- [x] Desativar permanente com reserva ativa: marcadas como `disponivel=false` com aviso de data no dialog
- [x] Reativar: unidades voltam a `disponivel=true`
- [x] Remover inativo bloqueado: dialog "Exclusão bloqueada" quando reservasAtivas > quartosAtivos
- [x] Delete parcial (C4) e total (C3) validados com seed de teste
- [ ] Estado vazio: hotel sem quartos exibe CTA "Adicionar primeiro quarto"
- [ ] Pull-to-refresh recarrega a lista do backend
- [ ] Erro de rede: mensagem de erro com botão "Tentar novamente"
- [ ] Navegação para `edit_room_page` e `add_room_page`
- [ ] Acessibilidade: `semanticLabel` verificado em leitor de tela
- [ ] Responsividade: portrait e landscape

🤖 Gerado com [Claude Code](https://claude.com/claude-code)