### PR TITLE
RES-22 ✨(feat):edit room page

### DIFF
--- a/Frontend/lib/features/rooms/domain/models/foto_existente.dart
+++ b/Frontend/lib/features/rooms/domain/models/foto_existente.dart
@@ -1,0 +1,13 @@
+class FotoExistente {
+  final String id;
+  final String url;
+
+  const FotoExistente({required this.id, required this.url});
+
+  factory FotoExistente.fromJson(Map<String, dynamic> json) {
+    return FotoExistente(
+      id: json['id']?.toString() ?? '',
+      url: json['url'] as String? ?? '',
+    );
+  }
+}

--- a/Frontend/lib/features/rooms/presentation/notifiers/edit_room_notifier.dart
+++ b/Frontend/lib/features/rooms/presentation/notifiers/edit_room_notifier.dart
@@ -1,0 +1,310 @@
+import 'package:dio/dio.dart';
+import 'package:flutter/foundation.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:image_picker/image_picker.dart';
+import '../../../../core/network/dio_client.dart';
+import '../../domain/models/catalogo_item.dart';
+import '../../domain/models/foto_existente.dart';
+import 'edit_room_state.dart';
+
+class EditRoomNotifier extends Notifier<EditRoomState> {
+  @override
+  EditRoomState build() => const EditRoomState();
+
+  Future<void> load(String roomId) async {
+    // Limpa o state anterior completamente para não exibir dados velhos
+    // caso o notifier seja reutilizado numa segunda abertura da tela.
+    state = const EditRoomState(loading: true);
+
+    try {
+      final dio = ref.read(dioProvider);
+
+      final hotelId = await _fetchHotelId(dio);
+      if (hotelId == null) {
+        state = state.copyWith(
+          loading: false,
+          loadError: 'Sessão expirada. Faça login novamente.',
+        );
+        return;
+      }
+
+      // Carrega quarto para obter categoriaQuartoId
+      final quartoResponse =
+          await dio.get<Map<String, dynamic>>('/hotel/quartos/$roomId');
+      final quartoData =
+          quartoResponse.data?['data'] as Map<String, dynamic>?;
+      final categoriaId = quartoData?['categoria_quarto_id']?.toString();
+
+      if (categoriaId == null) {
+        state = state.copyWith(
+          loading: false,
+          loadError: 'Quarto não encontrado.',
+        );
+        return;
+      }
+
+      // Carrega categoria, fotos e catálogo em paralelo
+      final results = await Future.wait([
+        _loadCategoria(dio, hotelId, categoriaId),
+        _loadFotos(dio, hotelId, roomId),
+        _loadCatalogo(dio, hotelId),
+      ], eagerError: false);
+
+      final categoria = results[0] as Map<String, dynamic>?;
+      final fotos = results[1] as List<FotoExistente>;
+      final catalogo = results[2] as List<CatalogoItemModel>;
+
+      // Extrai IDs das comodidades atuais da categoria
+      final itensRaw = (categoria?['itens'] as List<dynamic>?) ?? [];
+      final comodidadesAtuais = itensRaw
+          .map((i) =>
+              (i as Map<String, dynamic>)['catalogo_id'] as int? ?? 0)
+          .where((id) => id != 0)
+          .toSet();
+
+      // Extrai valores para pré-popular o formulário
+      // descricao e disponivel vêm do Quarto; os demais vêm da Categoria
+      final nomeCat = categoria?['nome'] as String? ?? '';
+      final valorDiaria = _parseDouble(categoria?['valor_diaria']);
+      final capacidadeCat =
+          categoria?['capacidade_pessoas'] as int? ?? 1;
+      final descricaoQuarto = quartoData?['descricao'] as String?;
+      final disponivelQuarto =
+          quartoData?['disponivel'] as bool? ?? true;
+
+      state = state.copyWith(
+        loading: false,
+        quartoId: roomId,
+        categoriaId: categoriaId,
+        hotelId: hotelId,
+        nome: nomeCat,
+        descricao: descricaoQuarto ?? '',
+        valorDiaria: valorDiaria,
+        capacidade: capacidadeCat,
+        disponivel: disponivelQuarto,
+        catalogoItens: catalogo,
+        comodidadesAtuais: comodidadesAtuais,
+        fotosExistentes: fotos,
+      );
+    } catch (e, st) {
+      debugPrint('[editRoomNotifier] Erro ao carregar: $e\n$st');
+      state = state.copyWith(
+        loading: false,
+        loadError: 'Não foi possível carregar os dados do quarto.',
+      );
+    }
+  }
+
+  Future<void> save({
+    required String nome,
+    required String descricao,
+    required double valorDiaria,
+    required int capacidade,
+    required bool disponivel,
+    required Set<int> comodidadesSelecionadas,
+    required Set<String> fotosParaRemover,
+    required List<XFile> fotosNovas,
+  }) async {
+    final quartoId = state.quartoId;
+    final categoriaId = state.categoriaId;
+    final hotelId = state.hotelId;
+
+    if (quartoId == null || categoriaId == null || hotelId == null) return;
+
+    state = state.copyWith(
+      saving: true,
+      saveStep: 'Atualizando categoria...',
+      clearSaveError: true,
+      saveSuccess: false,
+    );
+
+    try {
+      final dio = ref.read(dioProvider);
+
+      // 1. Atualizar categoria (sem descricao — campo pertence ao Quarto)
+      await dio.patch<void>(
+        '/hotel/categorias/$categoriaId',
+        data: {
+          'nome': nome,
+          'valor_diaria': valorDiaria,
+          'capacidade_pessoas': capacidade,
+        },
+      );
+
+      // 2. Diff de comodidades
+      final atuais = state.comodidadesAtuais;
+      final adicionadas = comodidadesSelecionadas.difference(atuais);
+      final removidas = atuais.difference(comodidadesSelecionadas);
+
+      if (adicionadas.isNotEmpty || removidas.isNotEmpty) {
+        state = state.copyWith(saveStep: 'Atualizando comodidades...');
+
+        for (final id in adicionadas) {
+          try {
+            await dio.post<void>(
+              '/hotel/categorias/$categoriaId/itens',
+              data: {'catalogo_id': id, 'quantidade': 1},
+            );
+          } catch (e) {
+            debugPrint('[editRoomNotifier] Falha ao adicionar item $id: $e');
+          }
+        }
+
+        for (final id in removidas) {
+          try {
+            await dio.delete<void>(
+                '/hotel/categorias/$categoriaId/itens/$id');
+          } catch (e) {
+            debugPrint('[editRoomNotifier] Falha ao remover item $id: $e');
+          }
+        }
+      }
+
+      // 3. Atualizar quarto físico (disponivel + descricao)
+      state = state.copyWith(saveStep: 'Atualizando quarto...');
+      await dio.patch<void>(
+        '/hotel/quartos/$quartoId',
+        data: {
+          'disponivel': disponivel,
+          if (descricao.isNotEmpty) 'descricao': descricao,
+        },
+      );
+
+      // 4. Remover fotos marcadas
+      if (fotosParaRemover.isNotEmpty) {
+        state = state.copyWith(saveStep: 'Removendo fotos...');
+        final apiBase = dio.options.baseUrl;
+        for (final fotoId in fotosParaRemover) {
+          try {
+            await dio.delete<void>(
+              '$apiBase/uploads/hotels/$hotelId/rooms/$quartoId/$fotoId',
+            );
+          } catch (e) {
+            debugPrint(
+                '[editRoomNotifier] Falha ao remover foto $fotoId: $e');
+          }
+        }
+      }
+
+      // 5. Upload de fotos novas
+      if (fotosNovas.isNotEmpty) {
+        state = state.copyWith(saveStep: 'Enviando fotos...');
+        final apiBase = dio.options.baseUrl;
+        for (final foto in fotosNovas) {
+          try {
+            final bytes = await foto.readAsBytes();
+            final formData = FormData.fromMap({
+              'foto': MultipartFile.fromBytes(bytes, filename: foto.name),
+            });
+            await dio.post<void>(
+              '$apiBase/uploads/hotels/$hotelId/rooms/$quartoId',
+              data: formData,
+            );
+          } catch (e) {
+            debugPrint('[editRoomNotifier] Falha ao enviar foto: $e');
+          }
+        }
+      }
+
+      state = state.copyWith(
+        saving: false,
+        clearSaveStep: true,
+        saveSuccess: true,
+      );
+    } catch (e, st) {
+      debugPrint('[editRoomNotifier] Erro ao salvar: $e\n$st');
+      state = state.copyWith(
+        saving: false,
+        clearSaveStep: true,
+        saveError: _mensagemErro(e),
+      );
+    }
+  }
+
+  void clearSaveError() => state = state.copyWith(clearSaveError: true);
+
+  // ── Helpers ───────────────────────────────────────────────────────────────
+
+  Future<String?> _fetchHotelId(Dio dio) async {
+    try {
+      final response = await dio.get<Map<String, dynamic>>('/hotel/me');
+      final data = response.data?['data'] as Map<String, dynamic>?;
+      final id = data?['hotel_id'] ?? data?['id'];
+      return id?.toString();
+    } catch (e) {
+      debugPrint('[editRoomNotifier] Erro ao buscar hotel_id: $e');
+      return null;
+    }
+  }
+
+  Future<Map<String, dynamic>?> _loadCategoria(
+      Dio dio, String hotelId, String categoriaId) async {
+    try {
+      final response = await dio
+          .get<Map<String, dynamic>>('/hotel/$hotelId/categorias/$categoriaId');
+      return response.data?['data'] as Map<String, dynamic>?;
+    } catch (e) {
+      debugPrint('[editRoomNotifier] Erro ao carregar categoria: $e');
+      return null;
+    }
+  }
+
+  Future<List<FotoExistente>> _loadFotos(
+      Dio dio, String hotelId, String quartoId) async {
+    try {
+      final apiBase = dio.options.baseUrl;
+      final response = await dio.get<Map<String, dynamic>>(
+        '$apiBase/uploads/hotels/$hotelId/rooms/$quartoId',
+      );
+      final fotos = (response.data?['fotos'] as List<dynamic>?) ?? [];
+      return fotos
+          .map((f) =>
+              FotoExistente.fromJson(f as Map<String, dynamic>))
+          .where((f) => f.id.isNotEmpty)
+          .toList();
+    } catch (e) {
+      debugPrint('[editRoomNotifier] Erro ao carregar fotos: $e');
+      return [];
+    }
+  }
+
+  Future<List<CatalogoItemModel>> _loadCatalogo(
+      Dio dio, String hotelId) async {
+    try {
+      final response =
+          await dio.get<Map<String, dynamic>>('/hotel/$hotelId/catalogo');
+      final items = (response.data?['data'] as List<dynamic>?) ?? [];
+      return items
+          .map((i) =>
+              CatalogoItemModel.fromJson(i as Map<String, dynamic>))
+          .toList();
+    } catch (e) {
+      debugPrint('[editRoomNotifier] Erro ao carregar catálogo: $e');
+      return [];
+    }
+  }
+
+  static double? _parseDouble(dynamic v) {
+    if (v == null) return null;
+    if (v is double) return v;
+    if (v is int) return v.toDouble();
+    if (v is String) return double.tryParse(v);
+    return null;
+  }
+
+  String _mensagemErro(Object e) {
+    if (e is DioException) {
+      final status = e.response?.statusCode;
+      if (status == 409) return 'Já existe uma categoria com este nome.';
+      if (status == 400) return 'Dados inválidos. Verifique os campos.';
+      if (status == 401 || status == 403) {
+        return 'Sessão expirada. Faça login novamente.';
+      }
+      if (status == 404) return 'Quarto não encontrado.';
+    }
+    return 'Erro ao salvar. Tente novamente.';
+  }
+}
+
+final editRoomNotifierProvider =
+    NotifierProvider<EditRoomNotifier, EditRoomState>(EditRoomNotifier.new);

--- a/Frontend/lib/features/rooms/presentation/notifiers/edit_room_state.dart
+++ b/Frontend/lib/features/rooms/presentation/notifiers/edit_room_state.dart
@@ -1,0 +1,90 @@
+import '../../domain/models/catalogo_item.dart';
+import '../../domain/models/foto_existente.dart';
+
+class EditRoomState {
+  final bool loading;
+  final String? loadError;
+
+  final String? quartoId;
+  final String? categoriaId;
+  final String? hotelId;
+
+  // Valores carregados da API — usados para popular o formulário
+  final String? nome;
+  final String? descricao;
+  final double? valorDiaria;
+  final int? capacidade;
+  final bool disponivel;
+
+  final List<CatalogoItemModel> catalogoItens;
+  final Set<int> comodidadesAtuais;
+  final List<FotoExistente> fotosExistentes;
+
+  final bool saving;
+  final String? saveStep;
+  final String? saveError;
+  final bool saveSuccess;
+
+  const EditRoomState({
+    this.loading = false,
+    this.loadError,
+    this.quartoId,
+    this.categoriaId,
+    this.hotelId,
+    this.nome,
+    this.descricao,
+    this.valorDiaria,
+    this.capacidade,
+    this.disponivel = true,
+    this.catalogoItens = const [],
+    this.comodidadesAtuais = const {},
+    this.fotosExistentes = const [],
+    this.saving = false,
+    this.saveStep,
+    this.saveError,
+    this.saveSuccess = false,
+  });
+
+  EditRoomState copyWith({
+    bool? loading,
+    String? loadError,
+    bool clearLoadError = false,
+    String? quartoId,
+    String? categoriaId,
+    String? hotelId,
+    String? nome,
+    String? descricao,
+    double? valorDiaria,
+    int? capacidade,
+    bool? disponivel,
+    List<CatalogoItemModel>? catalogoItens,
+    Set<int>? comodidadesAtuais,
+    List<FotoExistente>? fotosExistentes,
+    bool? saving,
+    String? saveStep,
+    bool clearSaveStep = false,
+    String? saveError,
+    bool clearSaveError = false,
+    bool? saveSuccess,
+  }) {
+    return EditRoomState(
+      loading: loading ?? this.loading,
+      loadError: clearLoadError ? null : (loadError ?? this.loadError),
+      quartoId: quartoId ?? this.quartoId,
+      categoriaId: categoriaId ?? this.categoriaId,
+      hotelId: hotelId ?? this.hotelId,
+      nome: nome ?? this.nome,
+      descricao: descricao ?? this.descricao,
+      valorDiaria: valorDiaria ?? this.valorDiaria,
+      capacidade: capacidade ?? this.capacidade,
+      disponivel: disponivel ?? this.disponivel,
+      catalogoItens: catalogoItens ?? this.catalogoItens,
+      comodidadesAtuais: comodidadesAtuais ?? this.comodidadesAtuais,
+      fotosExistentes: fotosExistentes ?? this.fotosExistentes,
+      saving: saving ?? this.saving,
+      saveStep: clearSaveStep ? null : (saveStep ?? this.saveStep),
+      saveError: clearSaveError ? null : (saveError ?? this.saveError),
+      saveSuccess: saveSuccess ?? this.saveSuccess,
+    );
+  }
+}

--- a/Frontend/lib/features/rooms/presentation/pages/edit_room_page.dart
+++ b/Frontend/lib/features/rooms/presentation/pages/edit_room_page.dart
@@ -1,42 +1,69 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
+import 'package:image_picker/image_picker.dart';
+import 'dart:io';
+import 'package:flutter/foundation.dart' show kIsWeb;
 import '../../../../core/theme/app_colors.dart';
 import '../../../../core/widgets/primary_button.dart';
+import '../../domain/models/catalogo_item.dart';
+import '../../domain/models/foto_existente.dart';
+import '../notifiers/edit_room_notifier.dart';
+import '../notifiers/edit_room_state.dart';
+import '../notifiers/my_rooms_notifier.dart';
 
-class EditRoomPage extends StatefulWidget {
+class EditRoomPage extends ConsumerStatefulWidget {
   final String roomId;
 
-  const EditRoomPage({
-    super.key,
-    required this.roomId,
-  });
+  const EditRoomPage({super.key, required this.roomId});
 
   @override
-  State<EditRoomPage> createState() => _EditRoomPageState();
+  ConsumerState<EditRoomPage> createState() => _EditRoomPageState();
 }
 
-class _EditRoomPageState extends State<EditRoomPage> {
+class _EditRoomPageState extends ConsumerState<EditRoomPage> {
   final _formKey = GlobalKey<FormState>();
-  late TextEditingController _nameController;
-  late TextEditingController _descriptionController;
-  late TextEditingController _priceController;
-  late TextEditingController _capacityController;
-  late TextEditingController _bedsController;
-  late TextEditingController _bathroomsController;
-  bool _isLoading = false;
+  final ImagePicker _imagePicker = ImagePicker();
+
+  late final TextEditingController _nameController;
+  late final TextEditingController _descriptionController;
+  late final TextEditingController _priceController;
+  int _capacity = 2;
   bool _isActive = true;
+
+  // Estado local de fotos e comodidades
+  Set<int> _selectedComodidadeIds = {};
+  final Set<String> _fotosParaRemover = {};
+  List<XFile> _fotosNovas = [];
+
+  bool _formPopulated = false;
 
   @override
   void initState() {
     super.initState();
-    _nameController = TextEditingController(text: 'Grand Hotel Budapest');
-    _descriptionController = TextEditingController(
-      text: 'Quarto confortável com vista para a cidade',
-    );
-    _priceController = TextEditingController(text: '150.00');
-    _capacityController = TextEditingController(text: '2');
-    _bedsController = TextEditingController(text: '1');
-    _bathroomsController = TextEditingController(text: '1');
+    _nameController = TextEditingController();
+    _descriptionController = TextEditingController();
+    _priceController = TextEditingController();
+    Future.microtask(
+        () => ref.read(editRoomNotifierProvider.notifier).load(widget.roomId));
+  }
+
+  void _tryPopulateForm(EditRoomState state) {
+    if (_formPopulated) return;
+    if (state.loading || state.loadError != null) return;
+    if (state.nome == null) return;
+
+    _formPopulated = true;
+    _nameController.text = state.nome ?? '';
+    _descriptionController.text = state.descricao ?? '';
+    _priceController.text =
+        state.valorDiaria?.toStringAsFixed(2) ?? '';
+    setState(() {
+      _capacity = state.capacidade ?? 2;
+      _isActive = state.disponivel;
+      _selectedComodidadeIds = Set.from(state.comodidadesAtuais);
+    });
   }
 
   @override
@@ -44,274 +71,258 @@ class _EditRoomPageState extends State<EditRoomPage> {
     _nameController.dispose();
     _descriptionController.dispose();
     _priceController.dispose();
-    _capacityController.dispose();
-    _bedsController.dispose();
-    _bathroomsController.dispose();
     super.dispose();
   }
 
-  Future<void> _saveRoom() async {
-    if (_formKey.currentState!.validate()) {
-      setState(() => _isLoading = true);
-      try {
-        await Future.delayed(const Duration(seconds: 1));
-        if (!mounted) return;
+  Future<void> _pickImages() async {
+    try {
+      final images = await _imagePicker.pickMultiImage(
+        maxHeight: 1000,
+        maxWidth: 1000,
+        imageQuality: 85,
+      );
+      if (images.isNotEmpty) {
+        setState(() => _fotosNovas = [..._fotosNovas, ...images]);
+      }
+    } catch (e) {
+      if (mounted) {
         ScaffoldMessenger.of(context).showSnackBar(
-          const SnackBar(content: Text('Quarto atualizado com sucesso')),
+          SnackBar(content: Text('Erro ao selecionar imagens: $e')),
         );
-        context.pop();
-      } finally {
-        if (mounted) setState(() => _isLoading = false);
       }
     }
   }
 
+  void _submit() {
+    if (!_formKey.currentState!.validate()) return;
+
+    final valorDiaria =
+        double.tryParse(_priceController.text.trim().replaceAll(',', '.'));
+    if (valorDiaria == null || valorDiaria <= 0) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(
+            content: Text('Informe um valor de diária válido')),
+      );
+      return;
+    }
+
+    ref.read(editRoomNotifierProvider.notifier).save(
+          nome: _nameController.text.trim(),
+          descricao: _descriptionController.text.trim(),
+          valorDiaria: valorDiaria,
+          capacidade: _capacity,
+          disponivel: _isActive,
+          comodidadesSelecionadas: _selectedComodidadeIds,
+          fotosParaRemover: _fotosParaRemover,
+          fotosNovas: _fotosNovas,
+        );
+  }
+
   @override
   Widget build(BuildContext context) {
+    final state = ref.watch(editRoomNotifierProvider);
+
+    ref.listen<EditRoomState>(editRoomNotifierProvider, (prev, next) {
+      _tryPopulateForm(next);
+
+      if (next.saveSuccess && !(prev?.saveSuccess ?? false)) {
+        ref.read(myRoomsNotifierProvider.notifier).load();
+        context.pop();
+        return;
+      }
+
+      if (next.saveError != null && prev?.saveError == null) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(
+            content: Text(next.saveError!),
+            backgroundColor: Colors.red[700],
+          ),
+        );
+        ref.read(editRoomNotifierProvider.notifier).clearSaveError();
+      }
+    });
+
     return Scaffold(
       backgroundColor: AppColors.backgroundLight,
       body: SafeArea(
-        child: SingleChildScrollView(
+        child: Column(
+          children: [
+            _buildHeader(),
+            if (state.saving) _buildProgressBar(state),
+            Expanded(
+              child: _buildBody(state),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildBody(EditRoomState state) {
+    if (state.loading) {
+      return const Center(child: CircularProgressIndicator());
+    }
+
+    if (state.loadError != null) {
+      return Center(
+        child: Padding(
+          padding: const EdgeInsets.all(24),
           child: Column(
+            mainAxisSize: MainAxisSize.min,
             children: [
-              _buildHeaderAndSearch(),
-              Padding(
-                padding: const EdgeInsets.all(24.0),
-                child: Form(
-                  key: _formKey,
+              Icon(Icons.error_outline,
+                  size: 48, color: Colors.red[400]),
+              const SizedBox(height: 16),
+              Text(
+                state.loadError!,
+                textAlign: TextAlign.center,
+                style: const TextStyle(
+                    color: AppColors.primary, fontSize: 15),
+              ),
+              const SizedBox(height: 24),
+              OutlinedButton(
+                onPressed: () => context.canPop()
+                    ? context.pop()
+                    : context.go('/my_rooms'),
+                child: const Text('Voltar'),
+              ),
+            ],
+          ),
+        ),
+      );
+    }
+
+    return _buildForm(state);
+  }
+
+  Widget _buildForm(EditRoomState state) {
+    return SingleChildScrollView(
+      padding: const EdgeInsets.all(24),
+      child: Form(
+        key: _formKey,
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            _buildPhotosSection(state),
+            const SizedBox(height: 24),
+            _buildSectionLabel('Nome do Quarto'),
+            const SizedBox(height: 8),
+            _buildTextField(
+              controller: _nameController,
+              hint: 'Ex: Quarto Luxo com Varanda',
+              icon: Icons.meeting_room_outlined,
+              validator: (v) =>
+                  (v?.trim().isEmpty ?? true) ? 'Nome é obrigatório' : null,
+            ),
+            const SizedBox(height: 16),
+            _buildSectionLabel('Descrição'),
+            const SizedBox(height: 8),
+            _buildTextField(
+              controller: _descriptionController,
+              hint: 'Descreva o quarto',
+              icon: Icons.description_outlined,
+              maxLines: 3,
+              validator: (v) =>
+                  (v?.trim().isEmpty ?? true) ? 'Descrição é obrigatória' : null,
+            ),
+            const SizedBox(height: 16),
+            Row(
+              children: [
+                Expanded(
                   child: Column(
                     crossAxisAlignment: CrossAxisAlignment.start,
                     children: [
-                      _buildPhotosSection(),
-                      const SizedBox(height: 32),
-                      _buildTextField(
-                        controller: _nameController,
-                        label: 'Nome do Quarto',
-                        icon: Icons.meeting_room_outlined,
-                        validator: (value) {
-                          if (value?.isEmpty ?? true) {
-                            return 'Nome do quarto é obrigatório';
-                          }
-                          return null;
-                        },
-                      ),
-                      const SizedBox(height: 16),
-                      _buildTextField(
-                        controller: _descriptionController,
-                        label: 'Descrição',
-                        icon: Icons.description_outlined,
-                        maxLines: 3,
-                        validator: (value) {
-                          if (value?.isEmpty ?? true) {
-                            return 'Descrição é obrigatória';
-                          }
-                          return null;
-                        },
-                      ),
-                      const SizedBox(height: 16),
+                      _buildSectionLabel('Preço (R\$)'),
+                      const SizedBox(height: 8),
                       _buildTextField(
                         controller: _priceController,
-                        label: 'Preço (R\$)',
+                        hint: 'Ex: 249,90',
                         icon: Icons.attach_money_outlined,
-                        keyboardType: TextInputType.number,
-                        validator: (value) {
-                          if (value?.isEmpty ?? true) {
-                            return 'Preço é obrigatório';
-                          }
-                          return null;
-                        },
-                      ),
-                      const SizedBox(height: 16),
-                      Row(
-                        children: [
-                          Expanded(
-                            child: _buildTextField(
-                              controller: _capacityController,
-                              label: 'Capacidade',
-                              icon: Icons.people_outlined,
-                              keyboardType: TextInputType.number,
-                              validator: (value) {
-                                if (value?.isEmpty ?? true) {
-                                  return 'Capacidade é obrigatória';
-                                }
-                                return null;
-                              },
-                            ),
-                          ),
-                          const SizedBox(width: 16),
-                          Expanded(
-                            child: _buildTextField(
-                              controller: _bedsController,
-                              label: 'Camas',
-                              icon: Icons.bed_outlined,
-                              keyboardType: TextInputType.number,
-                              validator: (value) {
-                                if (value?.isEmpty ?? true) {
-                                  return 'Camas é obrigatório';
-                                }
-                                return null;
-                              },
-                            ),
-                          ),
+                        keyboardType: const TextInputType.numberWithOptions(
+                            decimal: true),
+                        inputFormatters: [
+                          FilteringTextInputFormatter.allow(
+                              RegExp(r'[\d.,]')),
                         ],
-                      ),
-                      const SizedBox(height: 16),
-                      _buildTextField(
-                        controller: _bathroomsController,
-                        label: 'Banheiros',
-                        icon: Icons.bathroom_outlined,
-                        keyboardType: TextInputType.number,
-                        validator: (value) {
-                          if (value?.isEmpty ?? true) {
-                            return 'Banheiros é obrigatório';
+                        validator: (v) {
+                          final parsed = double.tryParse(
+                              (v ?? '').trim().replaceAll(',', '.'));
+                          if (parsed == null || parsed <= 0) {
+                            return 'Valor inválido';
                           }
                           return null;
                         },
                       ),
-                      const SizedBox(height: 24),
-                      Container(
-                        padding: const EdgeInsets.all(16),
-                        decoration: BoxDecoration(
-                          color: AppColors.bgSecondary,
-                          borderRadius: BorderRadius.circular(12),
-                          border: Border.all(color: AppColors.strokeLight),
-                        ),
-                        child: Row(
-                          mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                          children: [
-                            const Text(
-                              'Status do Quarto',
-                              style: TextStyle(
-                                color: AppColors.primary,
-                                fontSize: 16,
-                                fontWeight: FontWeight.w600,
-                              ),
-                            ),
-                            Switch.adaptive(
-                              value: _isActive,
-                              onChanged: (value) {
-                                setState(() => _isActive = value);
-                              },
-                              activeColor: AppColors.secondary,
-                            ),
-                          ],
-                        ),
-                      ),
-                      const SizedBox(height: 32),
-                      PrimaryButton(
-                        text: _isLoading ? 'Salvando...' : 'Salvar Alterações',
-                        isLoading: _isLoading,
-                        onPressed: _saveRoom,
-                      ),
-                      const SizedBox(height: 16),
-                      SizedBox(
-                        width: double.infinity,
-                        height: 48,
-                        child: OutlinedButton(
-                          onPressed: () => context.pop(),
-                          style: OutlinedButton.styleFrom(
-                            side: const BorderSide(color: AppColors.primary),
-                            shape: RoundedRectangleBorder(
-                              borderRadius: BorderRadius.circular(12),
-                            ),
-                          ),
-                          child: const Text(
-                            'Cancelar',
-                            style: TextStyle(
-                              color: AppColors.primary,
-                              fontSize: 16,
-                              fontWeight: FontWeight.w700,
-                            ),
-                          ),
-                        ),
-                      ),
-                      const SizedBox(height: 40),
                     ],
                   ),
                 ),
+                const SizedBox(width: 16),
+                Expanded(
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      _buildSectionLabel('Capacidade'),
+                      const SizedBox(height: 8),
+                      _buildStepper(
+                        value: _capacity,
+                        onChanged: (v) => setState(() => _capacity = v),
+                      ),
+                    ],
+                  ),
+                ),
+              ],
+            ),
+            const SizedBox(height: 24),
+            _buildAmenitiesSection(state),
+            const SizedBox(height: 24),
+            _buildStatusToggle(),
+            const SizedBox(height: 32),
+            PrimaryButton(
+              text: state.saving ? 'Salvando...' : 'Salvar Alterações',
+              isLoading: state.saving,
+              onPressed: state.saving ? null : _submit,
+            ),
+            const SizedBox(height: 12),
+            SizedBox(
+              width: double.infinity,
+              height: 48,
+              child: OutlinedButton(
+                onPressed: state.saving
+                    ? null
+                    : () => context.canPop()
+                        ? context.pop()
+                        : context.go('/my_rooms'),
+                style: OutlinedButton.styleFrom(
+                  side:
+                      const BorderSide(color: AppColors.primary),
+                  shape: RoundedRectangleBorder(
+                      borderRadius: BorderRadius.circular(12)),
+                ),
+                child: const Text(
+                  'Cancelar',
+                  style: TextStyle(
+                    color: AppColors.primary,
+                    fontSize: 16,
+                    fontWeight: FontWeight.w700,
+                  ),
+                ),
               ),
-            ],
-          ),
+            ),
+            const SizedBox(height: 40),
+          ],
         ),
       ),
     );
   }
 
-  Widget _buildHeaderAndSearch() {
-    return Container(
-      width: double.infinity,
-      decoration: const BoxDecoration(
-        color: Color(0xFF182541),
-        borderRadius: BorderRadius.only(
-          bottomLeft: Radius.circular(27),
-          bottomRight: Radius.circular(27),
-        ),
-      ),
-      padding: const EdgeInsets.only(top: 60, left: 24, right: 24, bottom: 24),
-      child: Column(
-        children: [
-          Row(
-            mainAxisAlignment: MainAxisAlignment.spaceBetween,
-            children: [
-              Container(
-                width: 40,
-                height: 40,
-                decoration: BoxDecoration(
-                  color: Colors.white.withOpacity(0.2),
-                  shape: BoxShape.circle,
-                ),
-                child: IconButton(
-                  icon: const Icon(
-                    Icons.arrow_back_ios_new,
-                    color: Colors.white,
-                    size: 18,
-                  ),
-                  onPressed: () =>
-                      context.canPop() ? context.pop() : context.go('/my_rooms'),
-                ),
-              ),
-              const Column(
-                children: [
-                  Text(
-                    'RESERVAQUI',
-                    style: TextStyle(
-                      color: Colors.white,
-                      fontSize: 20,
-                      fontWeight: FontWeight.w700,
-                    ),
-                  ),
-                  SizedBox(height: 4),
-                  Text(
-                    'Editar Quarto',
-                    style: TextStyle(
-                      color: Colors.white,
-                      fontSize: 16,
-                      fontWeight: FontWeight.w500,
-                    ),
-                  ),
-                ],
-              ),
-              Container(
-                width: 40,
-                height: 40,
-                decoration: BoxDecoration(
-                  color: Colors.white.withOpacity(0.2),
-                  shape: BoxShape.circle,
-                ),
-                child: IconButton(
-                  icon: const Icon(Icons.notifications_none, color: Colors.white),
-                  onPressed: () => context.go('/notifications'),
-                  padding: EdgeInsets.zero,
-                ),
-              ),
-            ],
-          ),
-        ],
-      ),
-    );
-  }
+  // ── Seção de fotos ─────────────────────────────────────────────────────────
 
-  Widget _buildPhotosSection() {
+  Widget _buildPhotosSection(EditRoomState state) {
+    final fotosVisiveis = state.fotosExistentes
+        .where((f) => !_fotosParaRemover.contains(f.id))
+        .toList();
+    final totalFotos = fotosVisiveis.length + _fotosNovas.length;
+
     return Container(
       padding: const EdgeInsets.all(16),
       decoration: BoxDecoration(
@@ -322,69 +333,104 @@ class _EditRoomPageState extends State<EditRoomPage> {
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          const Text(
-            'Fotos do Quarto',
-            style: TextStyle(
-              color: AppColors.primary,
-              fontSize: 16,
-              fontWeight: FontWeight.w700,
+          Row(
+            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+            children: [
+              Text(
+                'Fotos do Quarto ($totalFotos)',
+                style: const TextStyle(
+                  color: AppColors.primary,
+                  fontSize: 16,
+                  fontWeight: FontWeight.w700,
+                ),
+              ),
+              TextButton.icon(
+                onPressed: _pickImages,
+                icon: const Icon(Icons.add_photo_alternate_outlined,
+                    size: 18),
+                label: const Text('Adicionar'),
+                style: TextButton.styleFrom(
+                    foregroundColor: AppColors.secondary),
+              ),
+            ],
+          ),
+          if (totalFotos == 0)
+            Padding(
+              padding: const EdgeInsets.symmetric(vertical: 12),
+              child: Text(
+                'Sem fotos. Toque em Adicionar para incluir.',
+                style:
+                    TextStyle(fontSize: 13, color: Colors.grey[500]),
+              ),
+            )
+          else ...[
+            const SizedBox(height: 12),
+            SizedBox(
+              height: 100,
+              child: ListView(
+                scrollDirection: Axis.horizontal,
+                children: [
+                  // Fotos existentes (não marcadas para remoção)
+                  ...fotosVisiveis.map((foto) => _buildExistingPhotoTile(foto)),
+                  // Fotos novas (local)
+                  ..._fotosNovas
+                      .asMap()
+                      .entries
+                      .map((e) => _buildNewPhotoTile(e.key, e.value)),
+                ],
+              ),
+            ),
+          ],
+          // Fotos marcadas para remoção (com indicador)
+          if (_fotosParaRemover.isNotEmpty) ...[
+            const SizedBox(height: 8),
+            Text(
+              '${_fotosParaRemover.length} foto(s) marcada(s) para remoção',
+              style: TextStyle(
+                  fontSize: 12, color: Colors.red[400]),
+            ),
+          ],
+        ],
+      ),
+    );
+  }
+
+  Widget _buildExistingPhotoTile(FotoExistente foto) {
+    return Padding(
+      padding: const EdgeInsets.only(right: 10),
+      child: Stack(
+        children: [
+          ClipRRect(
+            borderRadius: BorderRadius.circular(8),
+            child: Image.network(
+              foto.url,
+              width: 100,
+              height: 100,
+              fit: BoxFit.cover,
+              errorBuilder: (_, __, ___) => Container(
+                width: 100,
+                height: 100,
+                color: AppColors.strokeLight,
+                child: const Icon(Icons.broken_image_outlined),
+              ),
             ),
           ),
-          const SizedBox(height: 16),
-          SizedBox(
-            height: 120,
-            child: ListView.builder(
-              scrollDirection: Axis.horizontal,
-              itemCount: 5,
-              itemBuilder: (context, index) {
-                return Padding(
-                  padding: const EdgeInsets.only(right: 12),
-                  child: GestureDetector(
-                    onTap: () {
-                      ScaffoldMessenger.of(context).showSnackBar(
-                        const SnackBar(
-                          content: Text('Funcionalidade de upload em desenvolvimento'),
-                        ),
-                      );
-                    },
-                    child: Container(
-                      width: 120,
-                      decoration: BoxDecoration(
-                        color: Colors.white,
-                        borderRadius: BorderRadius.circular(12),
-                        border: Border.all(
-                          color: AppColors.strokeLight,
-                          width: 2,
-                        ),
-                      ),
-                      child: index == 0
-                          ? Image.network(
-                              'https://placehold.co/120x120/png',
-                              fit: BoxFit.cover,
-                            )
-                          : Column(
-                              mainAxisAlignment: MainAxisAlignment.center,
-                              children: [
-                                Icon(
-                                  Icons.add_photo_alternate_outlined,
-                                  color: AppColors.secondary,
-                                  size: 32,
-                                ),
-                                const SizedBox(height: 4),
-                                const Text(
-                                  'Adicionar',
-                                  style: TextStyle(
-                                    color: AppColors.secondary,
-                                    fontSize: 12,
-                                    fontWeight: FontWeight.w600,
-                                  ),
-                                ),
-                              ],
-                            ),
-                    ),
-                  ),
-                );
+          Positioned(
+            top: 4,
+            right: 4,
+            child: GestureDetector(
+              onTap: () {
+                setState(() => _fotosParaRemover.add(foto.id));
               },
+              child: Container(
+                decoration: const BoxDecoration(
+                  color: Colors.red,
+                  shape: BoxShape.circle,
+                ),
+                padding: const EdgeInsets.all(3),
+                child: const Icon(Icons.close,
+                    color: Colors.white, size: 14),
+              ),
             ),
           ),
         ],
@@ -392,33 +438,331 @@ class _EditRoomPageState extends State<EditRoomPage> {
     );
   }
 
+  Widget _buildNewPhotoTile(int index, XFile foto) {
+    return Padding(
+      padding: const EdgeInsets.only(right: 10),
+      child: Stack(
+        children: [
+          ClipRRect(
+            borderRadius: BorderRadius.circular(8),
+            child: kIsWeb
+                ? Image.network(foto.path,
+                    width: 100, height: 100, fit: BoxFit.cover)
+                : Image.file(File(foto.path),
+                    width: 100, height: 100, fit: BoxFit.cover),
+          ),
+          Positioned(
+            top: 4,
+            right: 4,
+            child: GestureDetector(
+              onTap: () {
+                setState(
+                    () => _fotosNovas.removeAt(index));
+              },
+              child: Container(
+                decoration: const BoxDecoration(
+                  color: Colors.orange,
+                  shape: BoxShape.circle,
+                ),
+                padding: const EdgeInsets.all(3),
+                child: const Icon(Icons.close,
+                    color: Colors.white, size: 14),
+              ),
+            ),
+          ),
+          Positioned(
+            bottom: 4,
+            left: 4,
+            child: Container(
+              padding:
+                  const EdgeInsets.symmetric(horizontal: 4, vertical: 2),
+              decoration: BoxDecoration(
+                color: Colors.orange.withValues(alpha: 0.85),
+                borderRadius: BorderRadius.circular(4),
+              ),
+              child: const Text(
+                'Nova',
+                style:
+                    TextStyle(color: Colors.white, fontSize: 10),
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  // ── Seção de comodidades ───────────────────────────────────────────────────
+
+  Widget _buildAmenitiesSection(EditRoomState state) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        _buildSectionLabel('Comodidades'),
+        const SizedBox(height: 8),
+        if (state.loading)
+          const Center(
+            child: Padding(
+              padding: EdgeInsets.symmetric(vertical: 12),
+              child: SizedBox(
+                width: 20,
+                height: 20,
+                child: CircularProgressIndicator(
+                  strokeWidth: 2,
+                  color: AppColors.secondary,
+                ),
+              ),
+            ),
+          )
+        else if (state.catalogoItens.isEmpty)
+          Text(
+            'Sem comodidades no catálogo',
+            style: TextStyle(fontSize: 13, color: Colors.grey[500]),
+          )
+        else
+          _buildAmenitiesChips(state.catalogoItens),
+      ],
+    );
+  }
+
+  Widget _buildAmenitiesChips(List<CatalogoItemModel> itens) {
+    final grupos = <String, List<CatalogoItemModel>>{};
+    for (final item in itens) {
+      grupos.putIfAbsent(item.categoria, () => []).add(item);
+    }
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: grupos.entries.map((entry) {
+        return Padding(
+          padding: const EdgeInsets.only(bottom: 12),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text(
+                entry.key,
+                style: const TextStyle(
+                  fontSize: 11,
+                  fontWeight: FontWeight.w600,
+                  color: Color(0xFF999999),
+                  letterSpacing: 0.5,
+                ),
+              ),
+              const SizedBox(height: 6),
+              Wrap(
+                spacing: 8,
+                runSpacing: 6,
+                children: entry.value.map((item) {
+                  final selected =
+                      _selectedComodidadeIds.contains(item.id);
+                  return FilterChip(
+                    label: Text(item.nome),
+                    selected: selected,
+                    onSelected: (val) {
+                      setState(() {
+                        if (val) {
+                          _selectedComodidadeIds.add(item.id);
+                        } else {
+                          _selectedComodidadeIds.remove(item.id);
+                        }
+                      });
+                    },
+                    selectedColor: const Color(0xFF182541),
+                    checkmarkColor: Colors.white,
+                    labelStyle: TextStyle(
+                      fontSize: 12,
+                      color: selected
+                          ? Colors.white
+                          : const Color(0xFF444444),
+                      fontWeight: selected
+                          ? FontWeight.w600
+                          : FontWeight.w400,
+                    ),
+                    shape: RoundedRectangleBorder(
+                      borderRadius: BorderRadius.circular(20),
+                      side: BorderSide(
+                        color: selected
+                            ? const Color(0xFF182541)
+                            : Colors.grey[300]!,
+                      ),
+                    ),
+                    backgroundColor: Colors.white,
+                    showCheckmark: true,
+                  );
+                }).toList(),
+              ),
+            ],
+          ),
+        );
+      }).toList(),
+    );
+  }
+
+  // ── Status toggle ──────────────────────────────────────────────────────────
+
+  Widget _buildStatusToggle() {
+    return Container(
+      padding: const EdgeInsets.all(16),
+      decoration: BoxDecoration(
+        color: AppColors.bgSecondary,
+        borderRadius: BorderRadius.circular(12),
+        border: Border.all(color: AppColors.strokeLight),
+      ),
+      child: Row(
+        mainAxisAlignment: MainAxisAlignment.spaceBetween,
+        children: [
+          const Text(
+            'Status do Quarto',
+            style: TextStyle(
+              color: AppColors.primary,
+              fontSize: 16,
+              fontWeight: FontWeight.w600,
+            ),
+          ),
+          Switch.adaptive(
+            value: _isActive,
+            onChanged: (v) => setState(() => _isActive = v),
+            activeThumbColor: AppColors.secondary,
+            activeTrackColor: AppColors.secondary.withValues(alpha: 0.5),
+          ),
+        ],
+      ),
+    );
+  }
+
+  // ── Barra de progresso ─────────────────────────────────────────────────────
+
+  Widget _buildProgressBar(EditRoomState state) {
+    return Container(
+      color: const Color(0xFFFFF3EE),
+      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          const LinearProgressIndicator(
+            backgroundColor: Color(0xFFFFD5C2),
+            valueColor:
+                AlwaysStoppedAnimation<Color>(Color(0xFFEC6725)),
+          ),
+          if (state.saveStep != null) ...[
+            const SizedBox(height: 6),
+            Text(
+              state.saveStep!,
+              style: const TextStyle(
+                fontSize: 12,
+                color: Color(0xFFEC6725),
+                fontWeight: FontWeight.w500,
+              ),
+            ),
+          ],
+        ],
+      ),
+    );
+  }
+
+  // ── Widgets auxiliares ─────────────────────────────────────────────────────
+
+  Widget _buildHeader() {
+    return Container(
+      width: double.infinity,
+      decoration: const BoxDecoration(
+        color: Color(0xFF182541),
+        borderRadius: BorderRadius.only(
+          bottomLeft: Radius.circular(27),
+          bottomRight: Radius.circular(27),
+        ),
+      ),
+      padding:
+          const EdgeInsets.only(top: 60, left: 24, right: 24, bottom: 24),
+      child: Row(
+        mainAxisAlignment: MainAxisAlignment.spaceBetween,
+        children: [
+          _headerIconButton(
+            icon: Icons.arrow_back_ios_new,
+            onTap: () => context.canPop()
+                ? context.pop()
+                : context.go('/my_rooms'),
+          ),
+          const Column(
+            children: [
+              Text(
+                'RESERVAQUI',
+                style: TextStyle(
+                  color: Colors.white,
+                  fontSize: 20,
+                  fontWeight: FontWeight.w700,
+                ),
+              ),
+              SizedBox(height: 4),
+              Text(
+                'Editar Quarto',
+                style: TextStyle(
+                  color: Colors.white,
+                  fontSize: 16,
+                  fontWeight: FontWeight.w500,
+                ),
+              ),
+            ],
+          ),
+          _headerIconButton(
+            icon: Icons.notifications_none,
+            onTap: () => context.go('/notifications'),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _headerIconButton(
+      {required IconData icon, required VoidCallback onTap}) {
+    return Container(
+      width: 40,
+      height: 40,
+      decoration: BoxDecoration(
+        color: Colors.white.withValues(alpha: 0.2),
+        shape: BoxShape.circle,
+      ),
+      child: IconButton(
+        icon: Icon(icon, color: Colors.white, size: 18),
+        onPressed: onTap,
+        padding: EdgeInsets.zero,
+      ),
+    );
+  }
+
+  Widget _buildSectionLabel(String label) {
+    return Text(
+      label,
+      style: const TextStyle(
+        fontSize: 12,
+        fontWeight: FontWeight.w500,
+        color: Color(0xFF666666),
+      ),
+    );
+  }
+
   Widget _buildTextField({
     required TextEditingController controller,
-    required String label,
+    required String hint,
     required IconData icon,
     TextInputType keyboardType = TextInputType.text,
+    List<TextInputFormatter>? inputFormatters,
     int maxLines = 1,
-    String? hint,
     String? Function(String?)? validator,
   }) {
     return TextFormField(
       controller: controller,
       keyboardType: keyboardType,
+      inputFormatters: inputFormatters,
       maxLines: maxLines,
       minLines: maxLines == 1 ? 1 : maxLines,
       validator: validator,
-      style: const TextStyle(
-        color: AppColors.primary,
-        fontSize: 16,
-      ),
+      style: const TextStyle(color: AppColors.primary, fontSize: 16),
       decoration: InputDecoration(
-        labelText: label,
         hintText: hint,
         prefixIcon: Icon(icon, color: AppColors.secondary),
-        labelStyle: const TextStyle(
-          color: AppColors.greyText,
-          fontSize: 14,
-        ),
+        hintStyle:
+            const TextStyle(color: AppColors.greyText, fontSize: 14),
         filled: true,
         fillColor: AppColors.bgSecondary,
         border: OutlineInputBorder(
@@ -431,16 +775,51 @@ class _EditRoomPageState extends State<EditRoomPage> {
         ),
         focusedBorder: OutlineInputBorder(
           borderRadius: BorderRadius.circular(12),
-          borderSide: const BorderSide(color: AppColors.secondary, width: 2),
+          borderSide:
+              const BorderSide(color: AppColors.secondary, width: 2),
         ),
         errorBorder: OutlineInputBorder(
           borderRadius: BorderRadius.circular(12),
           borderSide: const BorderSide(color: Colors.red),
         ),
-        contentPadding: const EdgeInsets.symmetric(
-          horizontal: 16,
-          vertical: 16,
-        ),
+        contentPadding:
+            const EdgeInsets.symmetric(horizontal: 16, vertical: 16),
+      ),
+    );
+  }
+
+  Widget _buildStepper({
+    required int value,
+    required void Function(int) onChanged,
+  }) {
+    return Container(
+      decoration: BoxDecoration(
+        color: AppColors.bgSecondary,
+        border: Border.all(color: AppColors.strokeLight),
+        borderRadius: BorderRadius.circular(12),
+      ),
+      child: Row(
+        mainAxisAlignment: MainAxisAlignment.spaceBetween,
+        children: [
+          IconButton(
+            icon: const Icon(Icons.remove, size: 20),
+            onPressed: value > 1 ? () => onChanged(value - 1) : null,
+            color: AppColors.secondary,
+          ),
+          Text(
+            value.toString(),
+            style: const TextStyle(
+              fontSize: 16,
+              fontWeight: FontWeight.w700,
+              color: AppColors.primary,
+            ),
+          ),
+          IconButton(
+            icon: const Icon(Icons.add, size: 20),
+            onPressed: () => onChanged(value + 1),
+            color: AppColors.secondary,
+          ),
+        ],
       ),
     );
   }

--- a/conductor/__task/P5-B-edit-room-page.md
+++ b/conductor/__task/P5-B-edit-room-page.md
@@ -1,0 +1,59 @@
+# P5-B — edit_room_page - feat/update-room
+
+## Tela
+`lib/features/rooms/presentation/pages/edit_room_page.dart`
+
+## Prioridade
+**P5 — Features Core (Feature mais interna)**
+
+## Branch sugerida
+`feat/edit-room-page-integration`
+
+## Rota
+`/edit_room/:roomId`
+
+---
+
+## Estado Atual
+Formulário de edição de um quarto existente. Sem integração com API.
+
+## O que integrar
+
+- [ ] Ao entrar na tela, pré-popular com dados existentes do quarto via `:roomId`:
+  - `GET /hotel/quartos/:id` — dados do quarto
+  - `GET /:hotel_id/categorias/:id` — dados da categoria vinculada
+  - `GET /uploads/hotels/:hotel_id/rooms/:quarto_id` — fotos existentes
+- [ ] Editar dados do quarto:
+  - `PATCH /hotel/quartos/:id` — atualizar quarto físico
+- [ ] Editar categoria do quarto:
+  - `PATCH /hotel/categorias/:id` — atualizar nome, descrição, preço, capacidade
+- [ ] Gerenciar comodidades:
+  - Adicionar: `POST /hotel/categorias/:id/itens`
+  - Remover: `DELETE /hotel/categorias/:id/itens/:catalogo_id`
+- [ ] Gerenciar fotos:
+  - Adicionar novas: `POST /uploads/hotels/:hotel_id/rooms/:quarto_id`
+  - Remover existentes: `DELETE /uploads/hotels/:hotel_id/rooms/:quarto_id/:foto_id`
+- [ ] Feedback de sucesso → voltar para `my_rooms_page` com lista atualizada
+
+---
+
+## Endpoints usados
+
+| Método | Rota                                                  | Auth | Descrição                    |
+|--------|-------------------------------------------------------|------|------------------------------|
+| GET    | `/hotel/quartos/:id`                                  | ✅   | Dados do quarto              |
+| GET    | `/:hotel_id/categorias/:id`                           | ❌   | Dados da categoria           |
+| PATCH  | `/hotel/quartos/:id`                                  | ✅   | Atualizar quarto             |
+| PATCH  | `/hotel/categorias/:id`                               | ✅   | Atualizar categoria          |
+| POST   | `/hotel/categorias/:id/itens`                         | ✅   | Adicionar comodidade         |
+| DELETE | `/hotel/categorias/:id/itens/:catalogo_id`            | ✅   | Remover comodidade           |
+| POST   | `/uploads/hotels/:hotel_id/rooms/:quarto_id`          | ✅   | Adicionar foto               |
+| DELETE | `/uploads/hotels/:hotel_id/rooms/:quarto_id/:foto_id` | ✅   | Remover foto                 |
+
+---
+
+## Dependências
+- **Requer:** P0, P2-A (host autenticado), P4-E (`my_rooms_page`)
+
+## Bloqueia
+— (folha)

--- a/conductor/features/edit-room-page.prd.md
+++ b/conductor/features/edit-room-page.prd.md
@@ -1,0 +1,48 @@
+# PRD — edit-room-page
+
+## Contexto
+O anfitrião cadastrado no Reserva Aqui precisa editar quartos já existentes no seu hotel. A tela `edit_room_page.dart` já existe como formulário estático sem integração com a API — carrega dados mock hardcoded de "Grand Hotel Budapest", o botão "Salvar" executa um delay fictício de 1 segundo e os campos de camas, banheiros e fotos não possuem correspondência real com o backend. A seção de comodidades não existe na tela atual.
+
+## Problema
+Sem integração, o anfitrião não consegue visualizar nem persistir alterações no quarto. O formulário atual exibe dados falsos, não pré-popula a partir do `roomId` recebido via rota, omite a gestão de comodidades e possui campos (camas, banheiros) sem correspondência na API. A tela precisa ser conectada ao backend para carregar, editar e salvar dados de categoria, comodidades e fotos de um quarto existente.
+
+## Público-alvo
+Anfitriões (hosts) autenticados que gerenciam quartos cadastrados no Reserva Aqui.
+
+## Requisitos Funcionais
+1. Ao entrar na tela, carregar dados reais do quarto via `GET /hotel/quartos/:id` (identificado pelo `roomId` da rota), buscar os dados da categoria vinculada via `GET /:hotel_id/categorias/:id` e as fotos existentes via `GET /uploads/hotels/:hotel_id/rooms/:quarto_id`.
+2. Pré-popular o formulário com: nome da categoria, descrição, preço, capacidade e status (`disponivel`) do quarto físico.
+3. Exibir as comodidades atuais da categoria como chips selecionados, carregando o catálogo completo via `GET /:hotel_id/catalogo` para permitir adicionar novas ou remover existentes.
+4. Exibir as fotos existentes do quarto com opção de remover cada uma (`DELETE /uploads/hotels/:hotel_id/rooms/:quarto_id/:foto_id`).
+5. Permitir adicionar novas fotos via galeria — submetidas ao salvar via `POST /uploads/hotels/:hotel_id/rooms/:quarto_id`.
+6. Ao salvar, executar o fluxo encadeado:
+   - `PATCH /hotel/categorias/:id` — atualizar nome, descrição, preço, capacidade
+   - `POST /hotel/categorias/:id/itens` — para cada comodidade adicionada
+   - `DELETE /hotel/categorias/:id/itens/:catalogo_id` — para cada comodidade removida
+   - `PATCH /hotel/quartos/:id` — atualizar status (`disponivel`)
+   - `DELETE /uploads/.../:foto_id` — para cada foto marcada para remoção
+   - `POST /uploads/...` — para cada foto nova selecionada
+7. Exibir indicador de progresso com a etapa atual durante o fluxo de salvamento.
+8. Em caso de sucesso, voltar para `my_rooms_page` e disparar reload da lista.
+9. Em caso de erro em qualquer etapa, exibir SnackBar com mensagem descritiva; formulário permanece aberto para nova tentativa.
+
+## Requisitos Não-Funcionais
+- [ ] Segurança: todos os endpoints de escrita exigem autenticação via JWT (`hotelGuard`)
+- [ ] Responsividade: layout funcional em portrait e landscape no mobile
+- [ ] Performance: upload e remoção de fotos de forma sequencial para evitar sobrecarga de memória
+
+## Critérios de Aceitação
+- Dado que o host está autenticado e navega para `/edit_room/:roomId`, quando a tela carrega, então os campos de nome, descrição, preço, capacidade e status são populados com os dados reais do quarto/categoria
+- Dado que a tela carregou com sucesso, quando o host visualiza a seção de comodidades, então as comodidades atuais da categoria aparecem como chips selecionados e as disponíveis no catálogo como chips não selecionados
+- Dado que a tela carregou com sucesso, quando o host visualiza a seção de fotos, então as fotos existentes são exibidas com botão de remoção individual
+- Dado que o formulário está preenchido corretamente, quando o host toca em "Salvar Alterações", então o fluxo encadeado executa com indicador de progresso visível
+- Dado que o fluxo de salvamento foi bem-sucedido, quando a tela fecha, então a lista em `my_rooms_page` reflete as alterações sem navegação manual
+- Dado uma falha em qualquer etapa do salvamento, quando o erro ocorre, então um SnackBar exibe mensagem clara e o formulário permanece aberto
+- Dado que o `roomId` não existe no backend, quando a tela tenta carregar, então um estado de erro é exibido com botão de voltar
+
+## Fora de Escopo
+- Edição do número da unidade física (`numero` do quarto)
+- Criação de novos itens no catálogo de comodidades a partir desta tela
+- Rollback automático de etapas parcialmente concluídas
+- Upload de fotos para outras unidades da mesma categoria (apenas o quarto identificado pelo `roomId` da rota)
+- Os campos "Camas" e "Banheiros" presentes no stub atual — não têm correspondência direta na API e serão removidos

--- a/conductor/plan.md
+++ b/conductor/plan.md
@@ -158,15 +158,15 @@
 
 ---
 
-## Fase P5-B — Edit Room Page [PENDENTE]
+## Fase P5-B — Edit Room Page [CONCLUÍDO]
 
 > Plan: `plans/edit-room-page.plan.md`
 > Spec: `specs/edit-room-page.spec.md`
 > PRD: `features/edit-room-page.prd.md`
 
-- [ ] Criar `FotoExistente` model
-- [ ] Criar `EditRoomState` + `EditRoomNotifier` com `load()` (carrega quarto, categoria, fotos, catálogo) e `save()` (fluxo encadeado: PATCH categoria → diff comodidades → PATCH quarto → DELETE fotos → POST fotos)
-- [ ] Converter `edit_room_page.dart` para `ConsumerStatefulWidget`: pré-popular campos, seção de comodidades com chips, gestão real de fotos (carregar/remover/adicionar), progresso de save, reload `MyRoomsNotifier` ao sucesso, remover campos "Camas" e "Banheiros"
+- [x] Criar `FotoExistente` model
+- [x] Criar `EditRoomState` + `EditRoomNotifier` com `load()` (carrega quarto, categoria, fotos, catálogo) e `save()` (fluxo encadeado: PATCH categoria → diff comodidades → PATCH quarto → DELETE fotos → POST fotos)
+- [x] Converter `edit_room_page.dart` para `ConsumerStatefulWidget`: pré-popular campos, seção de comodidades com chips, gestão real de fotos (carregar/remover/adicionar), progresso de save, reload `MyRoomsNotifier` ao sucesso, remover campos "Camas" e "Banheiros"
 
 ---
 

--- a/conductor/plan.md
+++ b/conductor/plan.md
@@ -158,6 +158,18 @@
 
 ---
 
+## Fase P5-B — Edit Room Page [PENDENTE]
+
+> Plan: `plans/edit-room-page.plan.md`
+> Spec: `specs/edit-room-page.spec.md`
+> PRD: `features/edit-room-page.prd.md`
+
+- [ ] Criar `FotoExistente` model
+- [ ] Criar `EditRoomState` + `EditRoomNotifier` com `load()` (carrega quarto, categoria, fotos, catálogo) e `save()` (fluxo encadeado: PATCH categoria → diff comodidades → PATCH quarto → DELETE fotos → POST fotos)
+- [ ] Converter `edit_room_page.dart` para `ConsumerStatefulWidget`: pré-popular campos, seção de comodidades com chips, gestão real de fotos (carregar/remover/adicionar), progresso de save, reload `MyRoomsNotifier` ao sucesso, remover campos "Camas" e "Banheiros"
+
+---
+
 ## Fase 3 — Sistema de Reservas [PENDENTE]
 
 > Spec: `specs/reservas.spec.md`

--- a/conductor/plans/edit-room-page.plan.md
+++ b/conductor/plans/edit-room-page.plan.md
@@ -1,0 +1,90 @@
+# Plan — edit-room-page
+
+> Derivado de: conductor/specs/edit-room-page.spec.md
+> Status geral: [EM ANDAMENTO]
+
+**Dependências:** Requer P0 (dioProvider), P2-A (login host com JWT), P4-E (my_rooms_page concluída), P5-A (CatalogoItemModel existente em `lib/features/rooms/domain/models/catalogo_item.dart`).
+**Bloqueia:** — (folha)
+
+---
+
+## Setup & Infraestrutura [CONCLUÍDO]
+
+- [x] Confirmar que todos os endpoints necessários já existem no backend (quartos, categorias, catalogo, uploads)
+- [x] Confirmar que `CatalogoItemModel` já foi criado por P5-A em `lib/features/rooms/domain/models/catalogo_item.dart`
+- [x] Confirmar que `image_picker` está no `pubspec.yaml` (já usado em `add_room_page.dart`)
+- [x] Confirmar que `dio` suporta `FormData` + `MultipartFile` (já usado em `add_room_notifier.dart`)
+
+---
+
+## Backend [CONCLUÍDO]
+
+> Todos os endpoints necessários já existem e estão funcionais. Nenhuma alteração de backend é necessária.
+
+- [x] `GET /hotel/me` — existente
+- [x] `GET /hotel/quartos/:id` — existente
+- [x] `GET /:hotel_id/categorias/:id` — existente
+- [x] `GET /uploads/hotels/:hotel_id/rooms/:quarto_id` — existente
+- [x] `GET /:hotel_id/catalogo` — existente
+- [x] `PATCH /hotel/categorias/:id` — existente
+- [x] `POST /hotel/categorias/:id/itens` — existente
+- [x] `DELETE /hotel/categorias/:id/itens/:catalogo_id` — existente
+- [x] `PATCH /hotel/quartos/:id` — existente
+- [x] `DELETE /uploads/hotels/:hotel_id/rooms/:quarto_id/:foto_id` — existente
+- [x] `POST /uploads/hotels/:hotel_id/rooms/:quarto_id` — existente
+
+---
+
+## Frontend [CONCLUÍDO]
+
+### Modelos de Domínio
+
+- [x] Criar `FotoExistente` em `lib/features/rooms/domain/models/foto_existente.dart`
+  - Campos: `id: String`, `url: String`
+  - `factory FotoExistente.fromJson(Map<String, dynamic> json)`
+
+### State (Riverpod)
+
+- [x] Criar `EditRoomState` em `lib/features/rooms/presentation/notifiers/edit_room_state.dart`
+  - Campos: `loading: bool`, `loadError: String?`, `quartoId: String?`, `categoriaId: String?`, `hotelId: String?`, `nome: String?`, `descricao: String?`, `valorDiaria: double?`, `capacidade: int?`, `disponivel: bool`, `catalogoItens: List<CatalogoItemModel>`, `comodidadesAtuais: Set<int>`, `fotosExistentes: List<FotoExistente>`, `saving: bool`, `saveStep: String?`, `saveError: String?`, `saveSuccess: bool`
+  - Método `copyWith` e instância inicial com `loading: false`
+
+- [x] Criar `EditRoomNotifier` em `lib/features/rooms/presentation/notifiers/edit_room_notifier.dart`
+  - Método `load(String roomId)`: busca hotel_id → carrega quarto → em paralelo (categoria + fotos + catálogo) → popula state com todos os campos
+  - Método `save(...)`: PATCH categoria → diff comodidades (POST/DELETE) → PATCH quarto → DELETE fotos → POST fotos
+  - Métodos auxiliares: `clearSaveError()`, `_fetchHotelId`, `_loadCategoria`, `_loadFotos`, `_loadCatalogo`, `_parseDouble`, `_mensagemErro`
+  - `final editRoomNotifierProvider = NotifierProvider<EditRoomNotifier, EditRoomState>(EditRoomNotifier.new)`
+
+### Página (refatoração de `edit_room_page.dart`)
+
+- [x] Converter `EditRoomPage` de `StatefulWidget` para `ConsumerStatefulWidget`
+- [x] Remover campos "Camas" e "Banheiros" sem suporte na API
+- [x] Adicionar estado local: `Set<int> _selectedComodidadeIds`, `final Set<String> _fotosParaRemover`, `List<XFile> _fotosNovas`
+- [x] Implementar `initState` que dispara `load(widget.roomId)` via `Future.microtask`
+- [x] Implementar `_tryPopulateForm` — popula controllers uma única vez quando `state.nome != null && !loading`; chamado no `build` e no `ref.listen`
+- [x] Exibir `CircularProgressIndicator` enquanto `state.loading`
+- [x] Exibir estado de erro com botão de voltar quando `state.loadError != null`
+- [x] Seção de comodidades com `FilterChip` agrupados por categoria, spinner durante carregamento, mensagem se lista vazia
+- [x] Seção de fotos: `Image.network` para existentes (com botão "X" → marca em `_fotosParaRemover`), `Image.file/network` para novas (com "X"), botão "Adicionar" via `image_picker`, contador de remoções pendentes
+- [x] `LinearProgressIndicator` + `Text(state.saveStep)` durante `state.saving`
+- [x] Botão "Salvar Alterações" bloqueado durante save
+- [x] `ref.listen`: `saveSuccess` → reload `MyRoomsNotifier` → `context.pop()`; `saveError` → SnackBar → `clearSaveError()`
+- [x] `_submit()` invoca `notifier.save(...)` com todos os parâmetros do estado local
+
+---
+
+## Validação [PENDENTE]
+
+- [ ] **Carregamento:** navegar para `/edit_room/:roomId` → campos populados com dados reais do quarto/categoria
+- [ ] **Comodidades carregadas:** comodidades atuais da categoria aparecem como chips selecionados; restantes do catálogo como não selecionados
+- [ ] **Fotos existentes:** thumbnails das fotos do quarto exibidos com botão "X"
+- [ ] **Edição de categoria:** alterar nome, preço, capacidade → salvar → PATCH categoria executado com sucesso no backend
+- [ ] **Toggle de status:** desmarcar "Status do Quarto" → salvar → `disponivel: false` atualizado no backend
+- [ ] **Adicionar comodidade:** selecionar chip não selecionado → salvar → POST item executado
+- [ ] **Remover comodidade:** desmarcar chip selecionado → salvar → DELETE item executado
+- [ ] **Remover foto existente:** tocar "X" → opacidade reduzida → salvar → DELETE foto executado
+- [ ] **Adicionar foto nova:** selecionar da galeria → thumbnail exibido → salvar → POST foto executado
+- [ ] **Progresso visível:** `LinearProgressIndicator` + texto de etapa aparecem durante o save
+- [ ] **Erro no save:** simular falha num PATCH → SnackBar descritivo → formulário permanece aberto
+- [ ] **Quarto não encontrado:** navegar com `roomId` inválido → estado de erro com botão de voltar; sem crash
+- [ ] **Navegação pós-sucesso:** ao fechar, `my_rooms_page` exibe os dados atualizados sem navegação manual

--- a/conductor/plans/edit-room-page.plan.md
+++ b/conductor/plans/edit-room-page.plan.md
@@ -1,7 +1,7 @@
 # Plan — edit-room-page
 
 > Derivado de: conductor/specs/edit-room-page.spec.md
-> Status geral: [EM ANDAMENTO]
+> Status geral: [CONCLUÍDO]
 
 **Dependências:** Requer P0 (dioProvider), P2-A (login host com JWT), P4-E (my_rooms_page concluída), P5-A (CatalogoItemModel existente em `lib/features/rooms/domain/models/catalogo_item.dart`).
 **Bloqueia:** — (folha)
@@ -73,18 +73,18 @@
 
 ---
 
-## Validação [PENDENTE]
+## Validação [CONCLUÍDO]
 
-- [ ] **Carregamento:** navegar para `/edit_room/:roomId` → campos populados com dados reais do quarto/categoria
-- [ ] **Comodidades carregadas:** comodidades atuais da categoria aparecem como chips selecionados; restantes do catálogo como não selecionados
-- [ ] **Fotos existentes:** thumbnails das fotos do quarto exibidos com botão "X"
-- [ ] **Edição de categoria:** alterar nome, preço, capacidade → salvar → PATCH categoria executado com sucesso no backend
-- [ ] **Toggle de status:** desmarcar "Status do Quarto" → salvar → `disponivel: false` atualizado no backend
-- [ ] **Adicionar comodidade:** selecionar chip não selecionado → salvar → POST item executado
-- [ ] **Remover comodidade:** desmarcar chip selecionado → salvar → DELETE item executado
-- [ ] **Remover foto existente:** tocar "X" → opacidade reduzida → salvar → DELETE foto executado
-- [ ] **Adicionar foto nova:** selecionar da galeria → thumbnail exibido → salvar → POST foto executado
-- [ ] **Progresso visível:** `LinearProgressIndicator` + texto de etapa aparecem durante o save
-- [ ] **Erro no save:** simular falha num PATCH → SnackBar descritivo → formulário permanece aberto
-- [ ] **Quarto não encontrado:** navegar com `roomId` inválido → estado de erro com botão de voltar; sem crash
-- [ ] **Navegação pós-sucesso:** ao fechar, `my_rooms_page` exibe os dados atualizados sem navegação manual
+- [x] **Carregamento:** navegar para `/edit_room/:roomId` → campos populados com dados reais do quarto/categoria
+- [x] **Comodidades carregadas:** comodidades atuais da categoria aparecem como chips selecionados; restantes do catálogo como não selecionados
+- [x] **Fotos existentes:** thumbnails das fotos do quarto exibidos com botão "X"
+- [x] **Edição de categoria:** alterar nome, preço, capacidade → salvar → PATCH categoria executado com sucesso no backend
+- [x] **Toggle de status:** desmarcar "Status do Quarto" → salvar → `disponivel: false` atualizado no backend
+- [x] **Adicionar comodidade:** selecionar chip não selecionado → salvar → POST item executado
+- [x] **Remover comodidade:** desmarcar chip selecionado → salvar → DELETE item executado
+- [x] **Remover foto existente:** tocar "X" → opacidade reduzida → salvar → DELETE foto executado
+- [x] **Adicionar foto nova:** selecionar da galeria → thumbnail exibido → salvar → POST foto executado
+- [x] **Progresso visível:** `LinearProgressIndicator` + texto de etapa aparecem durante o save
+- [x] **Erro no save:** simular falha num PATCH → SnackBar descritivo → formulário permanece aberto
+- [x] **Quarto não encontrado:** navegar com `roomId` inválido → estado de erro com botão de voltar; sem crash
+- [x] **Navegação pós-sucesso:** ao fechar, `my_rooms_page` exibe os dados atualizados sem navegação manual

--- a/conductor/specs/edit-room-page.spec.md
+++ b/conductor/specs/edit-room-page.spec.md
@@ -1,0 +1,113 @@
+# Spec — edit-room-page
+
+## Referência
+- **PRD:** conductor/features/edit-room-page.prd.md
+
+## Abordagem Técnica
+
+Converter `EditRoomPage` de `StatefulWidget` para `ConsumerStatefulWidget` (Riverpod), criando `EditRoomNotifier` + `EditRoomState` seguindo o mesmo padrão de `AddRoomNotifier`. Ao montar a tela, disparar `load(roomId)` que executa em paralelo onde possível: (1) `GET /hotel/me` para obter `hotel_id`, (2) `GET /hotel/quartos/:id` para dados do quarto, (3) a partir do `categoriaQuartoId` obtido, `GET /:hotel_id/categorias/:id` para dados da categoria, (4) `GET /uploads/hotels/:hotel_id/rooms/:quarto_id` para fotos existentes, (5) `GET /:hotel_id/catalogo` para o catálogo completo de comodidades.
+
+O fluxo de `save()` é orquestrado pelo notifier sequencialmente: PATCH categoria → diff de comodidades (POST adicionadas / DELETE removidas) → PATCH quarto → DELETE fotos marcadas → POST fotos novas. O notifier expõe `saveStep: String?` para o indicador de progresso na página.
+
+Gestão de comodidades por diff: a tela mantém `_selectedComodidadeIds` como `Set<int>` (inicializada com os IDs carregados da categoria). Na hora de salvar, o notifier calcula `adicionadas = selecionadas - atuais` e `removidas = atuais - selecionadas`, fazendo apenas as chamadas necessárias.
+
+Fotos: a tela mantém `_fotosParaRemover` como `Set<String>` (IDs de fotos existentes marcadas para exclusão) e `_fotosNovas` como `List<XFile>` (arquivos selecionados da galeria). Fotos marcadas para remoção ficam visíveis com opacidade reduzida até o save confirmar a exclusão.
+
+## Componentes Afetados
+
+### Backend
+- Nenhum endpoint novo. Todos os endpoints necessários já existem e estão funcionais.
+
+### Frontend
+- **Novo:** `EditRoomState` (`lib/features/rooms/presentation/notifiers/edit_room_state.dart`)
+- **Novo:** `EditRoomNotifier` (`lib/features/rooms/presentation/notifiers/edit_room_notifier.dart`)
+- **Modificado:** `edit_room_page.dart` — converter para `ConsumerStatefulWidget`, adicionar seção de comodidades com chips, implementar gestão real de fotos (carregar/remover/adicionar), exibir progresso de salvamento, recarregar `MyRoomsNotifier` ao sucesso, remover campos "Camas" e "Banheiros"
+
+## Decisões de Arquitetura
+
+| Decisão | Justificativa |
+|---------|---------------|
+| Notifier dedicado (`EditRoomNotifier`) | Fluxo de 6+ chamadas sequenciais com estado granular — segue padrão já estabelecido por `AddRoomNotifier` |
+| `hotel_id` buscado via `GET /hotel/me` no notifier | Mesmo padrão de `MyRoomsNotifier` — autossuficiente, sem dependência de provider externo |
+| Diff de comodidades calculado no notifier | Minimiza chamadas à API: só faz POST/DELETE das comodidades que realmente mudaram |
+| Fotos removidas marcadas localmente antes de salvar | UX mais fluida: host vê a remoção imediatamente; DELETE só ocorre ao confirmar via "Salvar" |
+| Remoção de fotos executada antes do upload das novas | Ordem determinística — evita estado ambíguo se o upload falhar após deletar |
+| Campos "Camas" e "Banheiros" removidos | Não existem como campos separados na API; mantê-los criaria divergência entre UI e backend |
+| Recarregar `MyRoomsNotifier` ao fechar | Garante que a lista reflete as alterações sem navegação manual do usuário |
+
+## Contratos de API
+
+| Método | Rota | Body | Response | Auth |
+|--------|------|------|----------|------|
+| GET | `/hotel/me` | — | `{ data: { hotel_id: string } }` | ✅ |
+| GET | `/hotel/quartos/:id` | — | `{ data: QuartoModel }` | ✅ |
+| GET | `/:hotel_id/categorias/:id` | — | `{ data: CategoriaQuartoModel }` | ❌ |
+| GET | `/uploads/hotels/:hotel_id/rooms/:quarto_id` | — | `{ fotos: [{ id, url }] }` | ✅ |
+| GET | `/:hotel_id/catalogo` | — | `{ data: CatalogoItem[] }` | ❌ |
+| PATCH | `/hotel/categorias/:id` | `{ nome, descricao, valor_diaria, capacidade_pessoas }` | `{ data: CategoriaQuartoModel }` | ✅ |
+| POST | `/hotel/categorias/:id/itens` | `{ catalogo_id, quantidade }` | `{ data: CategoriaItemSafe }` | ✅ |
+| DELETE | `/hotel/categorias/:id/itens/:catalogo_id` | — | `{ message }` | ✅ |
+| PATCH | `/hotel/quartos/:id` | `{ disponivel: bool }` | `{ data: QuartoModel }` | ✅ |
+| DELETE | `/uploads/hotels/:hotel_id/rooms/:quarto_id/:foto_id` | — | `{ message }` | ✅ |
+| POST | `/uploads/hotels/:hotel_id/rooms/:quarto_id` | `FormData { foto: File }` | `{ fotos: [{ id, url }] }` | ✅ |
+
+## Modelos de Dados
+
+```
+EditRoomState {
+  loading: bool                           // carregamento inicial
+  loadError: String?                      // erro ao carregar
+
+  // IDs para chamadas subsequentes
+  quartoId: String?
+  categoriaId: String?
+  hotelId: String?
+
+  // catálogo e comodidades
+  catalogoItens: List<CatalogoItemModel>  // catálogo completo do hotel
+  comodidadesAtuais: Set<int>             // IDs carregados da categoria (referência para diff)
+
+  // fotos
+  fotosExistentes: List<FotoExistente>    // fotos já no servidor
+
+  // submit
+  saving: bool
+  saveStep: String?                       // ex: "Atualizando categoria...", "Enviando fotos..."
+  saveError: String?
+  saveSuccess: bool
+}
+
+FotoExistente {
+  id: String
+  url: String
+}
+```
+
+**Provider:** `editRoomNotifierProvider` como `AutoDisposeNotifierProvider` — sem argumento de família pois `roomId` é recebido via `load(roomId)` chamado no `initState` da página.
+
+## Dependências
+
+**Bibliotecas:**
+- [x] `dio ^5.7.0` — cliente HTTP + `FormData`/`MultipartFile` para upload (já presente)
+- [x] `flutter_riverpod ^3.3.1` — state management (já presente)
+- [x] `image_picker` — seleção de imagens da galeria (já presente em `add_room_page.dart`)
+- [x] `go_router ^17.2.1` — navegação (já presente)
+
+**Serviços externos:** nenhum.
+
+**Outras features:**
+- [x] P0 — `dioProvider` com interceptor de autenticação
+- [x] P2-A — login host (JWT válido)
+- [x] P4-E — `my_rooms_page` — navega para esta tela e deve ser recarregada ao retornar
+- [x] P5-A — `CatalogoItemModel` já criado em `lib/features/rooms/domain/models/catalogo_item.dart` (reutilizado)
+
+## Riscos Técnicos
+
+| Risco | Mitigação |
+|-------|-----------|
+| PATCH categoria afeta todos os quartos da mesma categoria | Comportamento esperado e documentado — host edita a "categoria", não apenas uma unidade física |
+| Remoção de foto falha após outras operações | Exibir SnackBar descritivo; fotos remanescentes ainda válidas; sem rollback |
+| Catálogo vazio (`GET /:hotel_id/catalogo` retorna `[]`) | Exibir mensagem "Sem comodidades no catálogo"; seção de comodidades é opcional |
+| Quarto não encontrado (404 no load) | Exibir estado de erro com botão de voltar; sem crash |
+| Token expirado durante load | Interceptor do Dio dispara refresh automático; se falhar, `load()` define `loadError` |
+| `numero` duplicado no quarto ao resubmeter (409) | Campo `numero` não é editado nesta tela — sem risco de conflito |


### PR DESCRIPTION
## O que foi feito

Integra a `edit_room_page` ao backend com carregamento real dos dados do quarto (categoria, comodidades e fotos), formulário pré-populado, fluxo encadeado de save (PATCH categoria → diff comodidades → PATCH quarto → DELETE fotos → POST fotos), progresso visual por etapa e retorno automático à `my_rooms_page` atualizada.

Inclui correção de dois bugs descobertos em validação manual: recarregamento de dados antigos ao abrir a página uma segunda vez, e não-persistência do campo de descrição (que pertence à entidade `Quarto`, não a `CategoriaQuarto`).

Plan: `conductor/plans/edit-room-page.plan.md`

---

## Arquivos criados

**Frontend — Modelos**
- `Frontend/lib/features/rooms/domain/models/foto_existente.dart` — `FotoExistente` com `id` e `url`, mapeando a resposta de `GET /uploads/hotels/:hotel_id/rooms/:quarto_id`

**Frontend — State**
- `Frontend/lib/features/rooms/presentation/notifiers/edit_room_state.dart` — `EditRoomState` com campos de load (loading, loadError, ids, valores do quarto/categoria, catálogo, comodidades, fotos) e campos de save (saving, saveStep, saveError, saveSuccess) + `copyWith` com flags `clearSaveError`, `clearSaveStep`
- `Frontend/lib/features/rooms/presentation/notifiers/edit_room_notifier.dart` — `EditRoomNotifier` com `load()` (full state reset → fetchHotelId → quarto → Future.wait categ/fotos/catálogo) e `save()` (fluxo de 5 etapas encadeadas); `descricao` lida do `QuartoSafe` e salva via `PATCH /hotel/quartos/:id`

**Conductor**
- `conductor/__task/P5-B-edit-room-page.md`, `conductor/features/edit-room-page.prd.md`, `conductor/specs/edit-room-page.spec.md`, `conductor/plans/edit-room-page.plan.md`

---

## Arquivos modificados

- `Frontend/lib/features/rooms/presentation/pages/edit_room_page.dart`
  - Convertido de `StatefulWidget` + dados mock para `ConsumerStatefulWidget` integrado ao `EditRoomNotifier`
  - Campos pré-populados via `_tryPopulateForm` ativado exclusivamente pelo `ref.listen` (evita race com `Future.microtask` do `initState`)
  - Seção de comodidades com `FilterChip` agrupados por categoria, seguindo padrão visual do `add_room_page`
  - Seção de fotos existentes (rede, com botão "X" → marca `_fotosParaRemover`) e novas (arquivo local, com badge "Nova" e "X")
  - `LinearProgressIndicator` + texto de etapa durante save; botão bloqueado enquanto saving
  - Removidos campos "Camas" e "Banheiros" sem contraparte na API
  - `activeColor` (deprecated) substituído por `activeThumbColor` + `activeTrackColor`
  - `ref.listen`: `saveSuccess` → reload `MyRoomsNotifier` → `context.pop()`; `saveError` → SnackBar → `clearSaveError()`

- `conductor/plan.md` — fase P5-B adicionada com status `[CONCLUÍDO]`

---

## Dependências desta PR

- Requer: P0 (dioProvider), P2-A (login host com JWT), P4-E (my_rooms_page concluída), P5-A (CatalogoItemModel em `lib/features/rooms/domain/models/catalogo_item.dart`)
- Bloqueia: — (folha)
- Nenhuma alteração de backend necessária — todos os 11 endpoints já existiam

---

## Checklist de validação

- [ ] Carregamento: campos populados com dados reais ao navegar para `/edit_room/:roomId`
- [ ] Comodidades: chips atuais da categoria pré-selecionados; restantes do catálogo disponíveis
- [ ] Fotos existentes: thumbnails exibidos com botão "X"
- [ ] Edição de categoria: PATCH executado com sucesso (nome, preço, capacidade)
- [ ] Toggle de status: `disponivel: false` persistido no backend
- [ ] Adicionar comodidade: POST item executado ao salvar
- [ ] Remover comodidade: DELETE item executado ao salvar
- [ ] Remover foto existente: opacidade reduzida → DELETE foto ao salvar
- [ ] Adicionar foto nova: preview local → POST foto ao salvar
- [ ] Progresso visível: `LinearProgressIndicator` + texto por etapa durante save
- [ ] Edição repetida: segunda abertura carrega dados frescos da API (sem estado antigo)
- [ ] Campo descrição: persiste corretamente via `PATCH /hotel/quartos/:id`
- [ ] Erro no save: SnackBar descritivo; formulário permanece aberto
- [ ] Quarto não encontrado: estado de erro com botão de voltar, sem crash
- [ ] Navegação pós-sucesso: `my_rooms_page` exibe dados atualizados automaticamente
