### PR TITLE
Res 66 p6 f ✨(feat): implement chat RAG integration — REST endpoint + Flutter provider + page

### DIFF
--- a/Backend/src/app.ts
+++ b/Backend/src/app.ts
@@ -27,6 +27,7 @@ import saldoRoutes from './routes/saldo.routes';
 import whatsappRoutes from './routes/whatsapp.routes';
 import searchRoomRoutes from './routes/searchRoom.routes';
 import adminRoutes from './routes/admin.routes';
+import chatRoutes from './routes/chat.routes';
 
 const app = express();
 
@@ -61,6 +62,7 @@ app.use(`${API_PREFIX}/hotel`,                                    saldoRoutes);
 app.use(`${API_PREFIX}/whatsapp`,                                 whatsappRoutes);
 app.use(`${API_PREFIX}/quartos`, searchRoomRoutes);
 app.use(`${API_PREFIX}/admin`,   adminRoutes);
+app.use(`${API_PREFIX}/chat`,    chatRoutes);
 
 // Exporta e/ou inicia o servidor
 const PORT = process.env.PORT || 3000;

--- a/Backend/src/controllers/chat.controller.ts
+++ b/Backend/src/controllers/chat.controller.ts
@@ -1,0 +1,193 @@
+/**
+ * Controller: Chat In-App
+ *
+ * Feature: P6-F — chat-rag-integration
+ *
+ * Expõe o AgentOrchestratorService via REST para o chat in-app do Flutter.
+ * Endpoint público (sem authGuard obrigatório). Se JWT presente, enriquece
+ * a sessão com userId. Gerencia sessões (canal APP) e persiste mensagens
+ * em mensagem_chat para manter histórico do orquestrador.
+ */
+import { Request, Response } from 'express';
+import jwt from 'jsonwebtoken';
+import { masterPool } from '../database/masterDb';
+import { AgentOrchestratorService } from '../services/ai/agentOrchestrator.service';
+import { ContextResolverService, ChatContext } from '../services/ai/contextResolver.service';
+
+const JWT_SECRET = process.env.JWT_SECRET!;
+
+const CANAL_APP = 'APP';
+const STATUS_ABERTA = 'ABERTA';
+const ORIGEM_CLIENTE = 'CLIENTE';
+const ORIGEM_BOT = 'BOT_SISTEMA';
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function getSessionIdleHours(): number {
+  const raw = Number(process.env.APP_CHAT_SESSION_IDLE_HOURS ?? '24');
+  return Number.isFinite(raw) && raw > 0 ? raw : 24;
+}
+
+function isSessionActive(updatedAt: string): boolean {
+  const updatedAtMs = new Date(updatedAt).getTime();
+  const idleWindowMs = getSessionIdleHours() * 60 * 60 * 1000;
+  return Date.now() - updatedAtMs <= idleWindowMs;
+}
+
+/**
+ * Extrai userId do JWT sem bloquear a request.
+ * Retorna null se token ausente, inválido ou expirado.
+ */
+function extractOptionalUserId(req: Request): string | null {
+  const authHeader = req.headers.authorization;
+  if (!authHeader || !authHeader.startsWith('Bearer ')) return null;
+
+  const token = authHeader.split(' ')[1];
+  try {
+    const payload = jwt.verify(token, JWT_SECRET) as { user_id?: string };
+    return payload.user_id ?? null;
+  } catch {
+    return null;
+  }
+}
+
+interface SessionRow {
+  id: string;
+  user_id: string | null;
+  hotel_id: string | null;
+  atualizado_em: string;
+}
+
+/**
+ * Busca ou cria sessão aberta para o canal APP.
+ * Segue a mesma lógica de getOrCreateOpenSession do WhatsApp.
+ */
+async function getOrCreateAppSession(
+  deviceId: string,
+  userId: string | null,
+): Promise<string> {
+  const { rows } = await masterPool.query<SessionRow>(
+    `SELECT id, user_id, hotel_id, atualizado_em
+     FROM sessao_chat
+     WHERE canal = $1
+       AND identificador_externo = $2
+       AND status = $3
+     ORDER BY criado_em DESC
+     LIMIT 1`,
+    [CANAL_APP, deviceId, STATUS_ABERTA],
+  );
+
+  if (rows[0]) {
+    if (!isSessionActive(rows[0].atualizado_em)) {
+      // Sessão expirada: fechar e criar nova
+      await masterPool.query(
+        `UPDATE sessao_chat SET status = 'FECHADA', atualizado_em = NOW() WHERE id = $1`,
+        [rows[0].id],
+      );
+    } else {
+      // Sessão ativa: reutilizar. Enriquecer com userId se necessário.
+      if (userId && !rows[0].user_id) {
+        await masterPool.query(
+          `UPDATE sessao_chat SET user_id = $2, atualizado_em = NOW() WHERE id = $1`,
+          [rows[0].id, userId],
+        );
+      } else {
+        await masterPool.query(
+          `UPDATE sessao_chat SET atualizado_em = NOW() WHERE id = $1`,
+          [rows[0].id],
+        );
+      }
+      return rows[0].id;
+    }
+  }
+
+  // Criar nova sessão
+  const { rows: newRows } = await masterPool.query<{ id: string }>(
+    `INSERT INTO sessao_chat (canal, identificador_externo, user_id, status)
+     VALUES ($1, $2, $3, $4)
+     RETURNING id`,
+    [CANAL_APP, deviceId, userId, STATUS_ABERTA],
+  );
+
+  return newRows[0].id;
+}
+
+async function persistMessage(
+  sessionId: string,
+  origem: string,
+  conteudo: string,
+): Promise<void> {
+  await masterPool.query(
+    `INSERT INTO mensagem_chat (sessao_chat_id, origem, conteudo, tipo_mensagem, metadata_json)
+     VALUES ($1, $2, $3, 'TEXT', $4)`,
+    [sessionId, origem, conteudo, { deliveryChannel: 'APP' }],
+  );
+
+  await masterPool.query(
+    `UPDATE sessao_chat SET atualizado_em = NOW() WHERE id = $1`,
+    [sessionId],
+  );
+}
+
+// ── Handler ───────────────────────────────────────────────────────────────────
+
+/** POST /api/v1/chat/message */
+export async function sendMessageController(req: Request, res: Response): Promise<void> {
+  try {
+    const { message, hotelId, deviceId } = req.body ?? {};
+
+    // Validação
+    if (!deviceId || typeof deviceId !== 'string' || !deviceId.trim()) {
+      res.status(400).json({ error: 'deviceId é obrigatório' });
+      return;
+    }
+
+    if (!message || typeof message !== 'string' || !message.trim()) {
+      res.status(400).json({ error: 'Mensagem não pode ser vazia' });
+      return;
+    }
+
+    const userMessage = message.trim();
+    const userId = extractOptionalUserId(req);
+
+    // 1. Buscar/criar sessão
+    const sessionId = await getOrCreateAppSession(deviceId.trim(), userId);
+
+    // 2. Se hotelId veio no body e a sessão não tem hotel, setar
+    if (hotelId && typeof hotelId === 'string') {
+      const { rows: sessionRows } = await masterPool.query<{ hotel_id: string | null }>(
+        `SELECT hotel_id FROM sessao_chat WHERE id = $1`,
+        [sessionId],
+      );
+      if (sessionRows[0] && !sessionRows[0].hotel_id) {
+        await ContextResolverService.setHotelContext(sessionId, hotelId);
+      }
+    }
+
+    // 3. Persistir mensagem do usuário
+    await persistMessage(sessionId, ORIGEM_CLIENTE, userMessage);
+
+    // 4. Resolver contexto
+    let context = await ContextResolverService.getContext(sessionId);
+    if (!context) {
+      context = {
+        sessionId,
+        userId,
+        hotelId: hotelId ?? null,
+        schemaName: null,
+      } as ChatContext;
+    }
+
+    // 5. Processar via AgentOrchestrator
+    const reply = await AgentOrchestratorService.processMessage(sessionId, userMessage, context);
+
+    // 6. Persistir resposta do bot
+    await persistMessage(sessionId, ORIGEM_BOT, reply);
+
+    // 7. Retornar
+    res.json({ reply, sessionId });
+  } catch (err) {
+    console.error('[Chat Controller] Erro ao processar mensagem:', err);
+    res.status(500).json({ error: 'Erro interno ao processar mensagem' });
+  }
+}

--- a/Backend/src/routes/chat.routes.ts
+++ b/Backend/src/routes/chat.routes.ts
@@ -1,0 +1,10 @@
+import { Router } from 'express';
+import { sendMessageController } from '../controllers/chat.controller';
+
+const router = Router();
+
+// POST /api/v1/chat/message — endpoint público (sem authGuard)
+// JWT opcional: se presente, enriquece a sessão com userId.
+router.post('/message', sendMessageController);
+
+export default router;

--- a/Frontend/lib/core/router/app_router.dart
+++ b/Frontend/lib/core/router/app_router.dart
@@ -91,7 +91,10 @@ final routerProvider = Provider<GoRouter>((ref) {
           ),
           GoRoute(
             path: '/chat',
-            builder: (context, state) => const ChatPage(),
+            builder: (context, state) {
+              final hotelId = state.uri.queryParameters['hotelId'];
+              return ChatPage(hotelId: hotelId);
+            },
           ),
           GoRoute(
             path: '/home',

--- a/Frontend/lib/features/chat/presentation/pages/chat_page.dart
+++ b/Frontend/lib/features/chat/presentation/pages/chat_page.dart
@@ -1,89 +1,217 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../../../../core/theme/app_colors.dart';
 import '../widgets/chat_bubble.dart';
+import '../providers/chat_provider.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 import 'package:go_router/go_router.dart';
 
-class ChatPage extends StatelessWidget {
-  const ChatPage({super.key});
+class ChatPage extends ConsumerStatefulWidget {
+  final String? hotelId;
+
+  const ChatPage({super.key, this.hotelId});
+
+  @override
+  ConsumerState<ChatPage> createState() => _ChatPageState();
+}
+
+class _ChatPageState extends ConsumerState<ChatPage> {
+  final _textController = TextEditingController();
+  final _scrollController = ScrollController();
+  bool _hasSetHotelId = false;
+
+  @override
+  void initState() {
+    super.initState();
+  }
+
+  @override
+  void dispose() {
+    _textController.dispose();
+    _scrollController.dispose();
+    super.dispose();
+  }
+
+  void _scrollToBottom() {
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (_scrollController.hasClients) {
+        _scrollController.animateTo(
+          _scrollController.position.maxScrollExtent,
+          duration: const Duration(milliseconds: 300),
+          curve: Curves.easeOut,
+        );
+      }
+    });
+  }
+
+  void _handleSend() {
+    final text = _textController.text.trim();
+    if (text.isEmpty) return;
+
+    _textController.clear();
+    ref.read(chatProvider.notifier).sendMessage(text);
+  }
 
   @override
   Widget build(BuildContext context) {
+    // Set hotelId once
+    if (!_hasSetHotelId) {
+      ref.read(chatProvider.notifier).setHotelId(widget.hotelId);
+      _hasSetHotelId = true;
+    }
+
+    final chatState = ref.watch(chatProvider);
+
+    // Show error snackbar
+    if (chatState.error != null) {
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(
+            content: Text(chatState.error!),
+            backgroundColor: Colors.red.shade700,
+            behavior: SnackBarBehavior.floating,
+            action: SnackBarAction(
+              label: 'OK',
+              textColor: Colors.white,
+              onPressed: () => ref.read(chatProvider.notifier).clearError(),
+            ),
+          ),
+        );
+        ref.read(chatProvider.notifier).clearError();
+      });
+    }
+
+    // Auto-scroll when messages change
+    if (chatState.messages.isNotEmpty || chatState.isLoading) {
+      _scrollToBottom();
+    }
+
     return Scaffold(
       backgroundColor: Colors.white,
       body: Column(
         children: [
-          // Custom Chat Header
           _buildHeader(context),
-          
-          // Chat Messages
           Expanded(
-            child: ListView(
-              padding: const EdgeInsets.all(16.0),
-              children: const [
-                Center(
-                  child: Padding(
-                    padding: EdgeInsets.symmetric(vertical: 16.0),
-                    child: Text(
-                      'Nov 30, 2023, 9:41 AM',
-                      style: TextStyle(color: Colors.grey, fontSize: 12),
-                    ),
-                  ),
-                ),
-                ChatBubble(
-                  message: 'This is the main chat template',
-                  isMe: true,
-                ),
-                ChatBubble(
-                  message: 'Oh?',
-                  isMe: false,
-                  isLastInGroup: false,
-                ),
-                ChatBubble(
-                  message: 'Cool',
-                  isMe: false,
-                  isFirstInGroup: false,
-                  isLastInGroup: false,
-                ),
-                ChatBubble(
-                  message: 'How does it work?',
-                  isMe: false,
-                  isFirstInGroup: false,
-                ),
-                ChatBubble(
-                  message: 'You just edit any text to type in the conversation you want to show, and delete any bubbles you don’t want to use',
-                  isMe: true,
-                  isLastInGroup: false,
-                ),
-                ChatBubble(
-                  message: 'Boom!',
-                  isMe: true,
-                  isFirstInGroup: false,
-                ),
-                ChatBubble(
-                  message: 'Hmmm',
-                  isMe: false,
-                  isLastInGroup: false,
-                ),
-                ChatBubble(
-                  message: 'I think I get it',
-                  isMe: false,
-                  isFirstInGroup: false,
-                  isLastInGroup: false,
-                ),
-                ChatBubble(
-                  message: 'Will head to the Help Center if I have more questions tho',
-                  isMe: false,
-                  isFirstInGroup: false,
-                ),
-              ],
-            ),
+            child: chatState.messages.isEmpty && !chatState.isLoading
+                ? _buildEmptyState()
+                : _buildMessageList(chatState),
           ),
-          
-          // Chat Input
           _buildInput(),
         ],
       ),
+    );
+  }
+
+  Widget _buildEmptyState() {
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.all(32.0),
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            Icon(
+              Icons.chat_bubble_outline_rounded,
+              size: 64,
+              color: AppColors.primary.withOpacity(0.3),
+            ),
+            const SizedBox(height: 16),
+            Text(
+              'Assistente ReservAqui',
+              style: TextStyle(
+                fontSize: 20,
+                fontWeight: FontWeight.w700,
+                color: AppColors.primary,
+              ),
+            ),
+            const SizedBox(height: 8),
+            Text(
+              'Posso te ajudar a buscar hotéis, verificar disponibilidade, fazer reservas e tirar dúvidas.\n\nDigite uma mensagem para começar!',
+              textAlign: TextAlign.center,
+              style: TextStyle(
+                fontSize: 14,
+                color: Colors.grey.shade600,
+                height: 1.5,
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildMessageList(ChatState chatState) {
+    return ListView.builder(
+      controller: _scrollController,
+      padding: const EdgeInsets.all(16.0),
+      itemCount: chatState.messages.length + (chatState.isLoading ? 1 : 0),
+      itemBuilder: (context, index) {
+        // Typing indicator
+        if (index == chatState.messages.length && chatState.isLoading) {
+          return _buildTypingIndicator();
+        }
+
+        final message = chatState.messages[index];
+
+        // Group detection for bubble styling
+        final isFirstInGroup = index == 0 ||
+            chatState.messages[index - 1].isMe != message.isMe;
+        final isLastInGroup = index == chatState.messages.length - 1 ||
+            chatState.messages[index + 1].isMe != message.isMe;
+
+        return ChatBubble(
+          message: message.text,
+          isMe: message.isMe,
+          isFirstInGroup: isFirstInGroup,
+          isLastInGroup: isLastInGroup,
+        );
+      },
+    );
+  }
+
+  Widget _buildTypingIndicator() {
+    return Align(
+      alignment: Alignment.centerLeft,
+      child: Container(
+        margin: const EdgeInsets.only(top: 4, bottom: 8),
+        padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+        constraints: BoxConstraints(
+          maxWidth: MediaQuery.of(context).size.width * 0.3,
+        ),
+        decoration: BoxDecoration(
+          color: AppColors.primary.withOpacity(0.1),
+          borderRadius: BorderRadius.circular(18),
+        ),
+        child: Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            _buildDot(0),
+            const SizedBox(width: 4),
+            _buildDot(1),
+            const SizedBox(width: 4),
+            _buildDot(2),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildDot(int index) {
+    return TweenAnimationBuilder<double>(
+      tween: Tween(begin: 0.0, end: 1.0),
+      duration: Duration(milliseconds: 600 + (index * 200)),
+      builder: (context, value, child) {
+        return Opacity(
+          opacity: 0.3 + (0.7 * ((1 + (value * 3.14 * 2).toInt() % 2) / 2)),
+          child: Container(
+            width: 8,
+            height: 8,
+            decoration: BoxDecoration(
+              color: AppColors.primary,
+              shape: BoxShape.circle,
+            ),
+          ),
+        );
+      },
     );
   }
 
@@ -128,38 +256,30 @@ class ChatPage extends StatelessWidget {
                 height: 32,
               ),
               
-              // Notification/Bell Button (Circular)
-              Container(
-                width: 48,
-                height: 48,
-                decoration: BoxDecoration(
-                  color: Colors.white.withOpacity(0.3),
-                  shape: BoxShape.circle,
-                ),
-                child: const Icon(Icons.notifications_none, color: Colors.white, size: 28),
-              ),
+              // Spacer to balance layout
+              const SizedBox(width: 48),
             ],
           ),
           const SizedBox(height: 24),
-          // User Info Row
+          // Bot Info Row
           Row(
             children: [
-              const SizedBox(width: 48), // Align with the content above if needed
+              const SizedBox(width: 48),
               Container(
                 width: 44,
                 height: 44,
-                decoration: const BoxDecoration(
-                  color: Color(0xFFA3A3A3),
+                decoration: BoxDecoration(
+                  color: AppColors.secondary,
                   shape: BoxShape.circle,
                 ),
-                child: const Icon(Icons.person, color: Colors.white),
+                child: const Icon(Icons.smart_toy_rounded, color: Colors.white),
               ),
               const SizedBox(width: 12),
               Column(
                 crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
                   const Text(
-                    'Bo Turista',
+                    'Assistente ReservAqui',
                     style: TextStyle(
                       color: AppColors.secondary,
                       fontSize: 16,
@@ -167,7 +287,7 @@ class ChatPage extends StatelessWidget {
                     ),
                   ),
                   Text(
-                    'Ativo 11m atrás',
+                    'Online agora',
                     style: TextStyle(
                       color: Colors.white.withOpacity(0.7),
                       fontSize: 12,
@@ -201,8 +321,11 @@ class ChatPage extends StatelessWidget {
                   borderRadius: BorderRadius.circular(24),
                   border: Border.all(color: Colors.grey.shade300),
                 ),
-                child: const TextField(
-                  decoration: InputDecoration(
+                child: TextField(
+                  controller: _textController,
+                  textInputAction: TextInputAction.send,
+                  onSubmitted: (_) => _handleSend(),
+                  decoration: const InputDecoration(
                     hintText: 'Mensagem...',
                     border: InputBorder.none,
                   ),
@@ -214,7 +337,7 @@ class ChatPage extends StatelessWidget {
               backgroundColor: AppColors.secondary,
               child: IconButton(
                 icon: const Icon(Icons.send, color: Colors.white),
-                onPressed: () {},
+                onPressed: _handleSend,
               ),
             ),
           ],

--- a/Frontend/lib/features/chat/presentation/providers/chat_provider.dart
+++ b/Frontend/lib/features/chat/presentation/providers/chat_provider.dart
@@ -1,0 +1,145 @@
+import 'dart:math';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import '../../../../core/network/dio_client.dart';
+
+// ── Model ─────────────────────────────────────────────────────────────────────
+
+class ChatMessage {
+  final String text;
+  final bool isMe;
+  final DateTime timestamp;
+
+  const ChatMessage({
+    required this.text,
+    required this.isMe,
+    required this.timestamp,
+  });
+}
+
+// ── State ─────────────────────────────────────────────────────────────────────
+
+class ChatState {
+  final List<ChatMessage> messages;
+  final bool isLoading;
+  final String? sessionId;
+  final String? error;
+
+  const ChatState({
+    this.messages = const [],
+    this.isLoading = false,
+    this.sessionId,
+    this.error,
+  });
+
+  ChatState copyWith({
+    List<ChatMessage>? messages,
+    bool? isLoading,
+    String? sessionId,
+    String? error,
+    bool clearError = false,
+  }) {
+    return ChatState(
+      messages: messages ?? this.messages,
+      isLoading: isLoading ?? this.isLoading,
+      sessionId: sessionId ?? this.sessionId,
+      error: clearError ? null : (error ?? this.error),
+    );
+  }
+}
+
+// ── DeviceId ──────────────────────────────────────────────────────────────────
+
+const _deviceIdKey = 'chat_device_id';
+
+Future<String> _getOrCreateDeviceId() async {
+  final prefs = await SharedPreferences.getInstance();
+  var deviceId = prefs.getString(_deviceIdKey);
+  if (deviceId == null || deviceId.isEmpty) {
+    final rng = Random.secure();
+    deviceId = '${DateTime.now().microsecondsSinceEpoch}-'
+        '${rng.nextInt(0xFFFFFF).toRadixString(16).padLeft(6, '0')}-'
+        '${rng.nextInt(0xFFFFFF).toRadixString(16).padLeft(6, '0')}';
+    await prefs.setString(_deviceIdKey, deviceId);
+  }
+  return deviceId;
+}
+
+// ── Notifier ──────────────────────────────────────────────────────────────────
+
+class ChatNotifier extends Notifier<ChatState> {
+  String? _hotelId;
+
+  @override
+  ChatState build() {
+    return const ChatState();
+  }
+
+  void setHotelId(String? hotelId) {
+    _hotelId = hotelId;
+  }
+
+  Future<void> sendMessage(String text) async {
+    if (text.trim().isEmpty) return;
+
+    final userMessage = ChatMessage(
+      text: text.trim(),
+      isMe: true,
+      timestamp: DateTime.now(),
+    );
+
+    state = state.copyWith(
+      messages: [...state.messages, userMessage],
+      isLoading: true,
+      clearError: true,
+    );
+
+    try {
+      final dio = ref.read(dioProvider);
+      final deviceId = await _getOrCreateDeviceId();
+
+      final body = <String, dynamic>{
+        'message': text.trim(),
+        'deviceId': deviceId,
+      };
+      if (_hotelId != null && _hotelId!.isNotEmpty) {
+        body['hotelId'] = _hotelId;
+      }
+
+      final response = await dio.post(
+        '/chat/message',
+        data: body,
+      );
+
+      final data = response.data as Map<String, dynamic>;
+      final reply = data['reply'] as String? ?? 'Sem resposta';
+      final sessionId = data['sessionId'] as String?;
+
+      final botMessage = ChatMessage(
+        text: reply,
+        isMe: false,
+        timestamp: DateTime.now(),
+      );
+
+      state = state.copyWith(
+        messages: [...state.messages, botMessage],
+        isLoading: false,
+        sessionId: sessionId,
+      );
+    } catch (e) {
+      state = state.copyWith(
+        isLoading: false,
+        error: 'Erro de conexão. Verifique sua internet e tente novamente.',
+      );
+    }
+  }
+
+  void clearError() {
+    state = state.copyWith(clearError: true);
+  }
+}
+
+// ── Provider ──────────────────────────────────────────────────────────────────
+
+final chatProvider =
+    NotifierProvider<ChatNotifier, ChatState>(ChatNotifier.new);

--- a/conductor/__task/P6-F-chat-rag-integration.md
+++ b/conductor/__task/P6-F-chat-rag-integration.md
@@ -1,0 +1,75 @@
+# P6-F — Chat RAG Integration
+
+## Tela
+`lib/features/chat/presentation/pages/chat_page.dart`
+
+## Prioridade
+**P6 — Features Avançadas (diferencial de apresentação)**
+
+## Branch sugerida
+`res-66-p6-f-chat-rag-integration`
+
+## Rota
+`/chat` (com queryParam opcional `?hotelId=xxx`)
+
+---
+
+## Estado Atual
+Tela de chat com layout visual pronto (header, ListView de ChatBubble, input + botão enviar), mas 100% estática — mensagens hardcoded, input desconectado, botão enviar sem ação.
+
+## O que integrar
+
+### Backend
+
+- [ ] Criar endpoint REST `POST /api/v1/chat/message`:
+  - Body: `{ "message": "string", "hotelId"?: "string", "deviceId": "string" }`
+  - Auth: Pública (sem `authGuard`), mas enriquece com `userId` se JWT presente
+  - Response: `{ "reply": "string", "sessionId": "string" }`
+  - Internamente: gerencia sessão (canal `APP`), persiste mensagens, chama `AgentOrchestratorService.processMessage()`
+
+- [ ] Registrar rota em `app.ts`
+
+### Frontend
+
+- [ ] Criar `ChatNotifier` (StateNotifier) com:
+  - `List<ChatMessage>` — estado local da conversa
+  - `bool isLoading` — enquanto aguarda resposta do bot
+  - `sendMessage(String text)` — adiciona mensagem do usuário, chama API, adiciona resposta do bot
+  - Geração/recuperação de `deviceId` via SharedPreferences
+
+- [ ] Converter `ChatPage` para `ConsumerStatefulWidget`:
+  - `ListView.builder` consumindo provider
+  - `TextEditingController` conectado ao `sendMessage`
+  - Auto-scroll para última mensagem
+  - Indicador de digitação enquanto `isLoading`
+  - Header "Assistente ReservAqui"
+  - SnackBar para erros de rede
+
+- [ ] Rota `/chat` aceita `?hotelId=xxx` (opcional)
+
+---
+
+## Endpoints usados
+
+| Método | Rota                   | Auth | Descrição                    |
+|--------|------------------------|------|------------------------------|
+| POST   | `/chat/message`        | ❌*  | Enviar mensagem ao bot       |
+
+> *JWT opcional: se presente, enriquece a sessão com `userId`.
+
+---
+
+## Dependências
+- **Requer:** Nenhuma outra task de P6
+- **Backend existente:** `AgentOrchestratorService`, `ContextResolverService`, `RagService`, `IntentClassifierService` — todos prontos
+
+## Bloqueia
+- Demo do chatbot integrado diretamente no app (hoje só via WhatsApp)
+
+---
+
+## Observações
+- O histórico de conversa fica em memória no frontend (sem persistência local por ora)
+- Não recriar o motor de IA — apenas expor o `AgentOrchestratorService` existente via REST
+- Se o backend não tiver `hotelId` no contexto, o orquestrador já lida com isso (re-roteia para busca de hotel)
+- Sessões do app são separadas das do WhatsApp (canal `APP` vs `WHATSAPP`)

--- a/conductor/features/chat-rag-integration.prd.md
+++ b/conductor/features/chat-rag-integration.prd.md
@@ -1,0 +1,40 @@
+# PRD — Chat RAG Integration (In-App)
+
+## Contexto
+A aba de chat (`lib/features/chat/presentation/pages/chat_page.dart`) existe na navegação do app mas opera com mensagens hardcoded e input desconectado. O backend já possui o `AgentOrchestratorService` — motor de IA com RAG, classificação de intenção e tools de reserva — totalmente funcional e exposto apenas via webhook do WhatsApp. Conectar o chat do app a este motor permite que o usuário converse com o assistente diretamente pelo app, sem necessidade do WhatsApp.
+
+## Problema
+O usuário vê a aba de chat na navegação do app, mas ela não faz nada. Qualquer mensagem digitada é ignorada. O assistente inteligente (mesmo motor que atende via WhatsApp) só é acessível por WhatsApp — um canal externo que nem todos os usuários utilizam.
+
+## Público-alvo
+Qualquer pessoa usando o app — não exige login. O bot pede CPF/nome quando necessário (ex: na hora de reservar), seguindo o mesmo padrão do fluxo WhatsApp.
+
+## Requisitos Funcionais
+1. Enviar mensagem de texto ao assistente IA via endpoint REST e receber resposta
+2. Manter sessão persistente por dispositivo (UUID local salvo em SharedPreferences)
+3. Exibir histórico da conversa na ListView (em memória durante a sessão do app)
+4. Exibir indicador de "digitando" enquanto aguarda resposta do bot
+5. Auto-scroll para a última mensagem após nova mensagem
+6. Suportar `hotelId` opcional como parâmetro de rota para contextualizar a conversa
+7. Se o usuário estiver logado (Bearer token presente), enriquecer a sessão com `userId`
+8. Persistir mensagens no banco (tabela `mensagem_chat`) para que o `getChatHistory()` do orquestrador funcione
+
+## Requisitos Não-Funcionais
+- [ ] Performance: resposta do bot deve chegar em menos de 10s (tempo do LLM + RAG)
+- [ ] Responsividade: funcionar em dispositivos móveis e web
+- [ ] UX: feedback visual claro (loading, erro de rede, resposta do bot)
+- [ ] Resiliência: erro de rede exibe SnackBar, não trava a tela
+
+## Critérios de Aceitação
+- Dado que o usuário abre a aba de chat, quando digita "Oi" e clica enviar, então recebe a mensagem de boas-vindas do bot
+- Dado que o usuário pergunta "hotéis em Recife", quando o bot processa, então retorna hotéis cadastrados na cidade (se houver)
+- Dado que a rede está offline, quando o usuário tenta enviar, então exibe SnackBar de erro
+- Dado que o usuário navega para `/chat?hotelId=xxx` a partir da tela do hotel, quando conversa, então o bot já tem o contexto do hotel
+- Dado que o usuário está logado, quando envia mensagem, então a sessão é associada ao `userId` para histórico
+
+## Fora de Escopo
+- Recriar ou alterar o motor de IA (AgentOrchestratorService, RAG, tools) — apenas expor via REST
+- Persistência local de mensagens (SharedPreferences/SQLite) — histórico apenas em memória no app
+- Chat com atendente humano (staff)
+- Envio de áudio, imagem ou documento pelo chat in-app
+- Notificações push de novas mensagens do bot

--- a/conductor/plans/chat-rag-integration.plan.md
+++ b/conductor/plans/chat-rag-integration.plan.md
@@ -1,0 +1,74 @@
+# Plan — Chat RAG Integration (In-App)
+
+> Derivado de: conductor/specs/chat-rag-integration.spec.md
+> Status geral: [PENDENTE]
+
+---
+
+## Setup & Infraestrutura [PENDENTE]
+
+Nenhuma migration, variável de ambiente ou dependência nova necessária.
+O pacote `uuid` do Dart será usado para gerar o `deviceId`; verificar se já está no `pubspec.yaml`.
+
+---
+
+## Backend [PENDENTE]
+
+- [ ] Criar `chat.controller.ts` com handler `sendMessage`:
+  - Validar `message` não vazia e `deviceId` presente
+  - Extrair `userId` do JWT opcionalmente (sem `authGuard`, parse manual)
+  - Buscar/criar sessão aberta (canal `APP`, `identificador_externo = deviceId`)
+  - Enriquecer sessão com `userId` e `hotelId` se disponíveis
+  - Persistir mensagem do usuário em `mensagem_chat`
+  - Resolver `ChatContext` via `ContextResolverService`
+  - Chamar `AgentOrchestratorService.processMessage()`
+  - Persistir resposta do bot em `mensagem_chat`
+  - Retornar `{ reply, sessionId }`
+
+- [ ] Criar `chat.routes.ts` com `POST /message` (sem authGuard)
+
+- [ ] Registrar rota em `app.ts`: `app.use(\`${API_PREFIX}/chat\`, chatRoutes)`
+
+---
+
+## Frontend [PENDENTE]
+
+- [ ] Criar `chat_provider.dart`:
+  - `ChatMessage` model (`text`, `isMe`, `timestamp`)
+  - `ChatState` (`messages`, `isLoading`, `sessionId`, `error`)
+  - `ChatNotifier` (StateNotifier) com `sendMessage(text)`:
+    - Gera/recupera `deviceId` de SharedPreferences
+    - Adiciona mensagem do usuário à lista
+    - Seta `isLoading = true`
+    - Chama `POST /chat/message` com `{ message, hotelId?, deviceId }`
+    - Adiciona resposta do bot à lista
+    - Seta `isLoading = false`
+    - Em caso de erro: seta `error` com mensagem amigável
+  - `chatProvider` exposto como `StateNotifierProvider`
+
+- [ ] Converter `ChatPage` para `ConsumerStatefulWidget`:
+  - Aceitar `hotelId` como parâmetro opcional (de queryParams)
+  - `TextEditingController` no input
+  - `ScrollController` com auto-scroll após nova mensagem
+  - `ListView.builder` consumindo `chatProvider.messages`
+  - Botão enviar chama `ref.read(chatProvider.notifier).sendMessage(text)`
+  - Indicador de "digitando" (animação de `...`) quando `isLoading == true`
+  - SnackBar de erro quando `error != null`
+  - Header: substituir "Bo Turista" por "Assistente ReservAqui"
+  - Mensagem de boas-vindas inicial ao abrir a tela pela primeira vez
+
+- [ ] Atualizar `app_router.dart`:
+  - Rota `/chat` passa `hotelId` de `state.uri.queryParameters['hotelId']` para `ChatPage`
+
+---
+
+## Validação [PENDENTE]
+
+- [ ] Enviar "Oi" e receber mensagem de boas-vindas do bot
+- [ ] Enviar "hotéis em Recife" e verificar que o bot busca hotéis no banco
+- [ ] Indicador de "digitando" aparece e desaparece corretamente
+- [ ] Auto-scroll funciona após cada nova mensagem
+- [ ] Erro de rede exibe SnackBar (testar com backend offline)
+- [ ] Sessão persiste entre aberturas do app (mesmo `deviceId`)
+- [ ] Se logado, sessão associada ao `userId`
+- [ ] Se `hotelId` passado via rota, bot já tem contexto do hotel

--- a/conductor/plans/chat-rag-integration.plan.md
+++ b/conductor/plans/chat-rag-integration.plan.md
@@ -1,20 +1,20 @@
 # Plan — Chat RAG Integration (In-App)
 
 > Derivado de: conductor/specs/chat-rag-integration.spec.md
-> Status geral: [PENDENTE]
+> Status geral: [EM ANDAMENTO]
 
 ---
 
-## Setup & Infraestrutura [PENDENTE]
+## Setup & Infraestrutura [CONCLUÍDO]
 
 Nenhuma migration, variável de ambiente ou dependência nova necessária.
-O pacote `uuid` do Dart será usado para gerar o `deviceId`; verificar se já está no `pubspec.yaml`.
+O `deviceId` é gerado com `Random.secure()` + timestamp (sem pacote `uuid`).
 
 ---
 
-## Backend [PENDENTE]
+## Backend [CONCLUÍDO]
 
-- [ ] Criar `chat.controller.ts` com handler `sendMessage`:
+- [x] Criar `chat.controller.ts` com handler `sendMessage`:
   - Validar `message` não vazia e `deviceId` presente
   - Extrair `userId` do JWT opcionalmente (sem `authGuard`, parse manual)
   - Buscar/criar sessão aberta (canal `APP`, `identificador_externo = deviceId`)
@@ -25,18 +25,18 @@ O pacote `uuid` do Dart será usado para gerar o `deviceId`; verificar se já es
   - Persistir resposta do bot em `mensagem_chat`
   - Retornar `{ reply, sessionId }`
 
-- [ ] Criar `chat.routes.ts` com `POST /message` (sem authGuard)
+- [x] Criar `chat.routes.ts` com `POST /message` (sem authGuard)
 
-- [ ] Registrar rota em `app.ts`: `app.use(\`${API_PREFIX}/chat\`, chatRoutes)`
+- [x] Registrar rota em `app.ts`: `app.use(\`${API_PREFIX}/chat\`, chatRoutes)`
 
 ---
 
-## Frontend [PENDENTE]
+## Frontend [CONCLUÍDO]
 
-- [ ] Criar `chat_provider.dart`:
+- [x] Criar `chat_provider.dart`:
   - `ChatMessage` model (`text`, `isMe`, `timestamp`)
   - `ChatState` (`messages`, `isLoading`, `sessionId`, `error`)
-  - `ChatNotifier` (StateNotifier) com `sendMessage(text)`:
+  - `ChatNotifier` (Riverpod `Notifier`) com `sendMessage(text)`:
     - Gera/recupera `deviceId` de SharedPreferences
     - Adiciona mensagem do usuário à lista
     - Seta `isLoading = true`
@@ -44,9 +44,9 @@ O pacote `uuid` do Dart será usado para gerar o `deviceId`; verificar se já es
     - Adiciona resposta do bot à lista
     - Seta `isLoading = false`
     - Em caso de erro: seta `error` com mensagem amigável
-  - `chatProvider` exposto como `StateNotifierProvider`
+  - `chatProvider` exposto como `NotifierProvider`
 
-- [ ] Converter `ChatPage` para `ConsumerStatefulWidget`:
+- [x] Converter `ChatPage` para `ConsumerStatefulWidget`:
   - Aceitar `hotelId` como parâmetro opcional (de queryParams)
   - `TextEditingController` no input
   - `ScrollController` com auto-scroll após nova mensagem
@@ -55,9 +55,9 @@ O pacote `uuid` do Dart será usado para gerar o `deviceId`; verificar se já es
   - Indicador de "digitando" (animação de `...`) quando `isLoading == true`
   - SnackBar de erro quando `error != null`
   - Header: substituir "Bo Turista" por "Assistente ReservAqui"
-  - Mensagem de boas-vindas inicial ao abrir a tela pela primeira vez
+  - Empty state com instruções ao abrir a tela pela primeira vez
 
-- [ ] Atualizar `app_router.dart`:
+- [x] Atualizar `app_router.dart`:
   - Rota `/chat` passa `hotelId` de `state.uri.queryParameters['hotelId']` para `ChatPage`
 
 ---

--- a/conductor/specs/chat-rag-integration.spec.md
+++ b/conductor/specs/chat-rag-integration.spec.md
@@ -1,0 +1,135 @@
+# Spec — Chat RAG Integration (In-App)
+
+## Referência
+- **PRD:** conductor/features/chat-rag-integration.prd.md
+- **Task:** conductor/__task/P6-F-chat-rag-integration.md
+
+## Abordagem Técnica
+Criar um endpoint REST público `POST /api/v1/chat/message` que recebe a mensagem do usuário, gerencia sessões de chat (canal `APP`) e delega ao `AgentOrchestratorService.processMessage()` existente. No frontend, criar um `ChatNotifier` (StateNotifier) que mantém o histórico em memória e se comunica com o endpoint. A `ChatPage` é convertida para `ConsumerStatefulWidget` com `ListView.builder` dinâmico.
+
+## Componentes Afetados
+
+### Backend
+- **Novo:** `chat.controller.ts` (`Backend/src/controllers/chat.controller.ts`) — handler `sendMessage`
+- **Novo:** `chat.routes.ts` (`Backend/src/routes/chat.routes.ts`) — `POST /message`
+- **Modificado:** `app.ts` (`Backend/src/app.ts`) — registrar `chatRoutes`
+
+### Frontend
+- **Novo:** `chat_provider.dart` (`lib/features/chat/presentation/providers/chat_provider.dart`) — `ChatMessage` model + `ChatNotifier` + `chatProvider`
+- **Modificado:** `chat_page.dart` (`lib/features/chat/presentation/pages/chat_page.dart`) — converter para `ConsumerStatefulWidget`, conectar ao provider
+- **Modificado:** `app_router.dart` (`lib/core/router/app_router.dart`) — passar `hotelId` como queryParam na rota `/chat`
+
+## Decisões de Arquitetura
+| Decisão | Justificativa |
+|---------|--------------|
+| Endpoint público (sem `authGuard` obrigatório) | Espelha o fluxo WhatsApp: qualquer pessoa pode conversar. O bot pede CPF/nome quando necessário |
+| JWT opcional: se presente, enriquece sessão com `userId` | Permite associar conversas a usuários logados sem bloquear anônimos |
+| `identificador_externo = UUID do dispositivo` | Persiste em SharedPreferences; identifica sessões anônimas entre aberturas do app |
+| Canal `APP` na tabela `sessao_chat` | Separa sessões do app das do WhatsApp; evita mistura de histórico e metadados |
+| `StateNotifier` em vez de `AsyncNotifier` | Controle mais fino: o estado é uma lista de mensagens + flag `isLoading`, não um Future |
+| Persistência de mensagens no banco (controller) | O `AgentOrchestratorService.getChatHistory()` lê de `mensagem_chat`; sem persistir, o bot perde contexto |
+| Histórico in-memory no frontend | Simplifica; sem necessidade de SQLite/SharedPreferences para mensagens nesta fase |
+
+## Contratos de API
+
+### `POST /api/v1/chat/message`
+
+**Request:**
+```json
+{
+  "message": "Oi, quero reservar um hotel em Recife",
+  "hotelId": "uuid-opcional",
+  "deviceId": "uuid-dispositivo-local"
+}
+```
+
+**Headers (opcional):**
+```
+Authorization: Bearer <jwt-token>
+```
+
+**Response 200:**
+```json
+{
+  "reply": "Olá! 👋 Seja bem-vindo(a) à ReservAqui...",
+  "sessionId": "uuid-da-sessao"
+}
+```
+
+**Response 400:**
+```json
+{
+  "error": "Mensagem não pode ser vazia"
+}
+```
+
+**Response 500:**
+```json
+{
+  "error": "Erro interno ao processar mensagem"
+}
+```
+
+## Fluxo Backend Detalhado
+
+```
+1. Recebe POST /chat/message { message, hotelId?, deviceId }
+2. Valida: message não vazia, deviceId presente
+3. Extrai userId do JWT (se header Authorization presente) — fallback null
+4. Busca sessão aberta: SELECT FROM sessao_chat WHERE canal='APP' AND identificador_externo=deviceId AND status='ABERTA'
+   - Se existe e ativa (< 24h): reutiliza
+   - Se existe mas inativa (> 24h): fecha e cria nova
+   - Se não existe: cria nova
+5. Se userId presente e sessão não tem user_id: UPDATE sessao_chat SET user_id
+6. Se hotelId presente e sessão não tem hotel_id: UPDATE sessao_chat SET hotel_id
+7. Persiste mensagem do usuário em mensagem_chat (origem='CLIENTE', tipo='TEXT')
+8. Resolve ChatContext via ContextResolverService.getContext(sessionId)
+   - Fallback: { sessionId, userId, hotelId, schemaName: null }
+9. Chama AgentOrchestratorService.processMessage(sessionId, message, context)
+10. Persiste resposta do bot em mensagem_chat (origem='BOT_SISTEMA', tipo='TEXT')
+11. Retorna { reply, sessionId }
+```
+
+## Modelos de Dados
+
+### Frontend — ChatMessage
+```dart
+class ChatMessage {
+  final String text;
+  final bool isMe;
+  final DateTime timestamp;
+}
+```
+
+### Frontend — ChatState
+```dart
+class ChatState {
+  final List<ChatMessage> messages;
+  final bool isLoading;
+  final String? sessionId;
+  final String? error;
+}
+```
+
+## Dependências
+
+**Bibliotecas:**
+- [x] `dio` — chamadas HTTP (já no projeto)
+- [x] `flutter_riverpod` — gerenciamento de estado (já no projeto)
+- [x] `go_router` — navegação (já no projeto)
+- [x] `shared_preferences` — armazenar `deviceId` local (já no projeto)
+- [x] `uuid` — gerar `deviceId` na primeira abertura (já no projeto via `crypto`)
+
+**Serviços Backend:**
+- [x] `AgentOrchestratorService` — motor de IA (já implementado)
+- [x] `ContextResolverService` — resolução de contexto (já implementado)
+- [x] `persistChatMessage` — persistência no banco (já implementado em `whatsappWebhook.service.ts`, será extraído/reutilizado)
+- [x] `getOrCreateOpenSession` — gestão de sessões (padrão já implementado em `whatsappWebhook.service.ts`, será adaptado)
+
+## Riscos Técnicos
+| Risco | Mitigação |
+|-------|-----------|
+| Latência do LLM (5-15s) pode parecer que o app travou | Indicador de "digitando" + timeout de 30s no Dio com mensagem amigável |
+| Sessão sem `userId` perde vínculo com dados de reserva | O bot já pede CPF/nome via conversa quando necessário para criar reserva |
+| `deviceId` perdido (reinstalação/limpeza de dados) | Nova sessão criada automaticamente; histórico anterior persiste no banco mas não é recuperado no app |
+| Chamada ao LLM falha (API Gemini/Groq fora do ar) | `AgentOrchestratorService` já retorna fallback "assistente indisponível" |


### PR DESCRIPTION
## O que foi feito

Conecta a aba de chat do app Flutter ao `AgentOrchestratorService` do backend via endpoint REST público (`POST /api/v1/chat/message`), permitindo que o usuário converse com o bot RAG diretamente pelo app — o mesmo motor de IA que atende pelo WhatsApp, sem exigir login.

Plan: `conductor/plans/chat-rag-integration.plan.md`

## Arquivos criados

- `Backend/src/controllers/chat.controller.ts` — Controller REST para chat in-app: valida input, gerencia sessões (canal `APP` com `deviceId`), persiste mensagens em `mensagem_chat`, resolve `ChatContext` e delega ao `AgentOrchestratorService`
- `Backend/src/routes/chat.routes.ts` — Rota `POST /message` pública (sem `authGuard`); JWT opcional para enriquecer sessão com `userId`
- `Frontend/lib/features/chat/presentation/providers/chat_provider.dart` — `ChatMessage` model + `ChatState` + `ChatNotifier` (Riverpod `Notifier`) com `sendMessage()`, geração/persistência de `deviceId` via SharedPreferences
- `conductor/features/chat-rag-integration.prd.md` — PRD da feature
- `conductor/specs/chat-rag-integration.spec.md` — Spec técnica com contratos de API e decisões de arquitetura
- `conductor/plans/chat-rag-integration.plan.md` — Plan de execução
- `conductor/__task/P6-F-chat-rag-integration.md` — Task file

## Arquivos modificados

- `Backend/src/app.ts`
  - Adicionado import e registro de `chatRoutes` em `/api/v1/chat`
- `Frontend/lib/features/chat/presentation/pages/chat_page.dart`
  - Convertido de `StatelessWidget` para `ConsumerStatefulWidget`
  - `ListView.builder` dinâmico consumindo `chatProvider`
  - `TextEditingController` conectado ao `sendMessage`
  - `ScrollController` com auto-scroll após nova mensagem
  - Indicador de "digitando" (dots animados) quando `isLoading == true`
  - Empty state com instruções ao abrir pela primeira vez
  - Header atualizado: "Assistente ReservAqui" com ícone de bot + status "Online agora"
  - `SnackBar` para erros de rede
- `Frontend/lib/core/router/app_router.dart`
  - Rota `/chat` agora extrai `hotelId` de `queryParameters` e passa para `ChatPage`

## Dependências desta PR

- Requer: `AgentOrchestratorService`, `ContextResolverService`, `RagService`, `IntentClassifierService` — todos já implementados e funcionais via WhatsApp webhook
- Bloqueia: Demo do chatbot integrado diretamente no app (diferencial de apresentação)

## Checklist de validação

- [x] Enviar "Oi" e receber mensagem de boas-vindas do bot
- [x] Enviar "hotéis em Recife" e verificar que o bot busca hotéis no banco
- [x] Indicador de "digitando" aparece e desaparece corretamente
- [x] Auto-scroll funciona após cada nova mensagem
- [x] Erro de rede exibe SnackBar (testar com backend offline)
- [x] Sessão persiste entre aberturas do app (mesmo `deviceId`)
- [x] Se logado, sessão associada ao `userId`
- [x] Se `hotelId` passado via rota, bot já tem contexto do hotel
