### PR TITLE
🐛(fix): RES-85 implement support email redirect with mailto and fallback SnackBar

### DIFF
--- a/Frontend/ios/Runner/Info.plist
+++ b/Frontend/ios/Runner/Info.plist
@@ -45,5 +45,9 @@
 	<true/>
 	<key>UIApplicationSupportsIndirectInputEvents</key>
 	<true/>
+	<key>LSApplicationQueriesSchemes</key>
+	<array>
+		<string>mailto</string>
+	</array>
 </dict>
 </plist>

--- a/Frontend/lib/core/constants/app_constants.dart
+++ b/Frontend/lib/core/constants/app_constants.dart
@@ -1,0 +1,3 @@
+class AppConstants {
+  static const String supportEmail = 'reserv.aqui.123@gmail.com';
+}

--- a/Frontend/lib/core/theme/app_colors.dart
+++ b/Frontend/lib/core/theme/app_colors.dart
@@ -5,4 +5,6 @@ import 'package:flutter/material.dart';
 class AppColors {
   static const Color primary = Color(0xFF182541);
   static const Color secondary = Color(0xFFEC6725);
+  static const Color greyText = Color(0xFF9E9E9E);
+  static const Color strokeLight = Color(0xFFE0E0E0);
 }

--- a/Frontend/lib/core/widgets/custom_bottom_nav.dart
+++ b/Frontend/lib/core/widgets/custom_bottom_nav.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/material.dart';
-import '../../../../core/theme/app_colors.dart';
+import '../theme/app_colors.dart';
 
 // ─── Ordem das abas conforme navbar.png ───────────────────────
 // 0: buscar | 1: curtidas | 2: início | 3: mensagens | 4: perfil

--- a/Frontend/lib/features/profile/presentation/pages/settings_page.dart
+++ b/Frontend/lib/features/profile/presentation/pages/settings_page.dart
@@ -7,6 +7,7 @@ import '../../../../core/theme/theme_notifier.dart';
 import 'terms_page.dart';
 import 'privacy_page.dart';
 import 'about_page.dart';
+import 'support_page.dart';
 
 const _notificationsKey = 'notifications_enabled';
 
@@ -147,6 +148,16 @@ class _SettingsPageState extends ConsumerState<SettingsPage> {
                       onTap: () => Navigator.push(
                         context,
                         MaterialPageRoute(builder: (_) => const AboutPage()),
+                      ),
+                    ),
+                    Divider(color: colorScheme.outline, height: 1, indent: 16, endIndent: 16),
+                    _buildActionTile(
+                      context: context,
+                      icon: Icons.support_agent_outlined,
+                      title: 'Suporte',
+                      onTap: () => Navigator.push(
+                        context,
+                        MaterialPageRoute(builder: (_) => const SupportPage()),
                       ),
                     ),
                   ],

--- a/Frontend/lib/features/profile/presentation/pages/support_page.dart
+++ b/Frontend/lib/features/profile/presentation/pages/support_page.dart
@@ -1,0 +1,116 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:url_launcher/url_launcher.dart' show launchUrl;
+import '../../../../core/constants/app_constants.dart';
+
+class SupportPage extends StatelessWidget {
+  const SupportPage({super.key});
+
+  Future<void> _openEmail(BuildContext context) async {
+    final uri = Uri(
+      scheme: 'mailto',
+      path: AppConstants.supportEmail,
+      queryParameters: {
+        'subject': 'Suporte ReservAqui',
+        'body': 'Olá, preciso de ajuda com...',
+      },
+    );
+
+    try {
+      await launchUrl(uri);
+    } catch (_) {
+      if (!context.mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(
+          content: Text('Copie o email: ${AppConstants.supportEmail}'),
+          action: SnackBarAction(
+            label: 'Copiar',
+            onPressed: () => Clipboard.setData(
+              ClipboardData(text: AppConstants.supportEmail),
+            ),
+          ),
+        ),
+      );
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Suporte'),
+      ),
+      body: SingleChildScrollView(
+        padding: const EdgeInsets.all(24),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(
+              'Precisa de ajuda?',
+              style: TextStyle(
+                fontSize: 22,
+                fontWeight: FontWeight.w800,
+                color: colorScheme.onSurface,
+              ),
+            ),
+            const SizedBox(height: 8),
+            Text(
+              'Entre em contato com nossa equipe de suporte. Respondemos em até 24 horas.',
+              style: TextStyle(
+                fontSize: 15,
+                height: 1.6,
+                color: colorScheme.onSurfaceVariant,
+              ),
+            ),
+            const SizedBox(height: 32),
+            Container(
+              decoration: BoxDecoration(
+                color: colorScheme.surface,
+                borderRadius: BorderRadius.circular(12),
+                border: Border.all(color: colorScheme.outline),
+              ),
+              child: InkWell(
+                onTap: () => _openEmail(context),
+                borderRadius: BorderRadius.circular(12),
+                child: Padding(
+                  padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 16),
+                  child: Row(
+                    children: [
+                      Icon(Icons.email_outlined, color: colorScheme.onSurfaceVariant, size: 24),
+                      const SizedBox(width: 16),
+                      Expanded(
+                        child: Column(
+                          crossAxisAlignment: CrossAxisAlignment.start,
+                          children: [
+                            Text(
+                              'Enviar email',
+                              style: TextStyle(
+                                fontSize: 16,
+                                fontWeight: FontWeight.w500,
+                                color: colorScheme.onSurface,
+                              ),
+                            ),
+                            Text(
+                              AppConstants.supportEmail,
+                              style: TextStyle(
+                                fontSize: 13,
+                                color: colorScheme.onSurfaceVariant,
+                              ),
+                            ),
+                          ],
+                        ),
+                      ),
+                      Icon(Icons.chevron_right, color: colorScheme.onSurfaceVariant),
+                    ],
+                  ),
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/Frontend/lib/features/profile/presentation/pages/user_profile_page.dart
+++ b/Frontend/lib/features/profile/presentation/pages/user_profile_page.dart
@@ -1,7 +1,10 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart' show Clipboard, ClipboardData;
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
+import 'package:url_launcher/url_launcher.dart' show launchUrl;
 import '../../../../core/auth/auth_notifier.dart';
+import '../../../../core/constants/app_constants.dart';
 import '../../../../core/theme/app_colors.dart';
 import '../../../../core/widgets/primary_button.dart';
 import '../providers/user_profile_provider.dart';
@@ -85,7 +88,32 @@ class UserProfilePage extends ConsumerWidget {
                     ProfileMenuItem(
                       title: 'suporte',
                       icon: Icons.headset_mic_outlined,
-                      onTap: () {},
+                      onTap: () async {
+                        final uri = Uri(
+                          scheme: 'mailto',
+                          path: AppConstants.supportEmail,
+                          queryParameters: {
+                            'subject': 'Suporte ReservAqui',
+                            'body': 'Olá, preciso de ajuda com...',
+                          },
+                        );
+                        try {
+                          await launchUrl(uri);
+                        } catch (_) {
+                          if (!context.mounted) return;
+                          ScaffoldMessenger.of(context).showSnackBar(
+                            SnackBar(
+                              content: Text('Copie o email: ${AppConstants.supportEmail}'),
+                              action: SnackBarAction(
+                                label: 'Copiar',
+                                onPressed: () => Clipboard.setData(
+                                  ClipboardData(text: AppConstants.supportEmail),
+                                ),
+                              ),
+                            ),
+                          );
+                        }
+                      },
                       showDivider: false,
                     ),
                   ],

--- a/conductor/features/suporte-email-redirect.prd.md
+++ b/conductor/features/suporte-email-redirect.prd.md
@@ -1,0 +1,29 @@
+# PRD — Suporte Email Redirect
+
+## Contexto
+A página de suporte do app ReservAqui oferece uma opção de contato por email, porém o redirecionamento para o app de email do dispositivo não está implementado. O usuário precisa copiar o endereço manualmente e iniciar o contato por conta própria.
+
+## Problema
+A ausência do redirecionamento via `mailto:` gera fricção desnecessária no fluxo de suporte. Sem assunto e corpo pré-preenchidos, o usuário não sabe quais informações fornecer, e o suporte recebe contatos incompletos.
+
+## Público-alvo
+Usuários finais (hóspedes) que precisam contatar o suporte diretamente pelo app.
+
+## Requisitos Funcionais
+1. Ao tocar na opção de suporte por email, abrir o app de email nativo com `mailto:` pré-configurado (destinatário, assunto e corpo)
+2. O email de suporte deve ser uma constante centralizada — não hardcodar em múltiplos lugares
+3. Caso o dispositivo não tenha app de email configurado, exibir `SnackBar` com o endereço `suporte@reservaqui.com` para o usuário copiar manualmente
+
+## Requisitos Não-Funcionais
+- [ ] Segurança: email de destino fixo via constante, sem input do usuário
+- [ ] Compatibilidade iOS: adicionar `mailto` em `LSApplicationQueriesSchemes` no `Info.plist`
+- [ ] Responsividade: funcionar em Android e iOS
+
+## Critérios de Aceitação
+- Dado que o usuário está na página de suporte, quando tocar no botão de email, então o app de email abre com destinatário `suporte@reservaqui.com`, assunto `Suporte ReservAqui` e corpo inicial pré-preenchido
+- Dado que o dispositivo não tem app de email configurado, quando tocar no botão, então um SnackBar exibe o endereço `suporte@reservaqui.com` para cópia manual
+
+## Fora de Escopo
+- Envio de email direto pelo app (sem app externo)
+- Suporte via chat ou WhatsApp
+- Histórico de contatos enviados pelo app

--- a/conductor/plans/suporte-email-redirect.plan.md
+++ b/conductor/plans/suporte-email-redirect.plan.md
@@ -1,0 +1,32 @@
+# Plan — Suporte Email Redirect
+
+> Derivado de: conductor/specs/suporte-email-redirect.spec.md
+> Status geral: [EM ANDAMENTO]
+
+---
+
+## Setup & Infraestrutura [CONCLUÍDO]
+
+- [x] Adicionar `LSApplicationQueriesSchemes: [mailto]` no `ios/Runner/Info.plist`
+
+---
+
+## Backend [CONCLUÍDO]
+
+Nenhuma task de backend.
+
+---
+
+## Frontend [CONCLUÍDO]
+
+- [x] Criar `lib/core/constants/app_constants.dart` com a constante `kSupportEmail`
+- [x] Criar `lib/features/profile/presentation/pages/support_page.dart` com botão de email usando `url_launcher`
+- [x] Implementar fallback `SnackBar` quando não houver app de email no dispositivo
+
+---
+
+## Validação [PENDENTE]
+
+- [ ] Tocar no botão de email — verificar se abre o app de email com destinatário, assunto e corpo pré-preenchidos
+- [ ] Simular dispositivo sem app de email — verificar se `SnackBar` exibe `suporte@reservaqui.com`
+- [ ] Verificar no iOS que `canLaunchUrl` não é bloqueado após a alteração no `Info.plist`

--- a/conductor/specs/suporte-email-redirect.spec.md
+++ b/conductor/specs/suporte-email-redirect.spec.md
@@ -1,0 +1,47 @@
+# Spec — Suporte Email Redirect
+
+## Referência
+- **PRD:** conductor/features/suporte-email-redirect.prd.md
+
+## Abordagem Técnica
+Feature exclusivamente frontend. Usar `url_launcher` (já presente no pubspec `^6.3.1`) para abrir o app de email nativo via esquema `mailto:` com destinatário, assunto e corpo pré-preenchidos. A `support_page.dart` será criada seguindo o padrão das páginas vizinhas em `lib/features/profile/presentation/pages/`. O email de suporte será centralizado em um novo `app_constants.dart`. O `Info.plist` do iOS receberá a declaração do scheme `mailto` para que `canLaunchUrl` funcione corretamente.
+
+## Componentes Afetados
+
+### Backend
+Nenhum.
+
+### Frontend
+- **Novo:** `SupportPage` (`lib/features/profile/presentation/pages/support_page.dart`)
+- **Novo:** `AppConstants` (`lib/core/constants/app_constants.dart`) — constante `kSupportEmail`
+- **Modificado:** `ios/Runner/Info.plist` — adicionar `LSApplicationQueriesSchemes` com `mailto`
+
+## Decisões de Arquitetura
+| Decisão | Justificativa |
+|---------|--------------|
+| Usar `url_launcher` | Já é dependência do projeto — evita código nativo adicional |
+| Constante em `app_constants.dart` | Evita email hardcodado espalhado pelo código |
+| `SnackBar` como fallback | Padrão Flutter para mensagens não-bloqueantes; não interrompe o fluxo |
+
+## Contratos de API
+Nenhum. Feature sem chamadas ao backend.
+
+## Modelos de Dados
+Nenhum. Feature sem persistência.
+
+## Dependências
+
+**Bibliotecas:**
+- [x] `url_launcher ^6.3.1` — já presente no pubspec; abrir app de email via `mailto:`
+
+**Configuração nativa:**
+- [ ] `ios/Runner/Info.plist` — adicionar `LSApplicationQueriesSchemes: [mailto]` (atualmente ausente)
+
+**Outras features:**
+Nenhuma.
+
+## Riscos Técnicos
+| Risco | Mitigação |
+|-------|-----------|
+| Dispositivo sem app de email configurado | Exibir `SnackBar` com `suporte@reservaqui.com` para cópia manual |
+| iOS bloqueando `canLaunchUrl` sem scheme declarado | Adicionar `mailto` em `LSApplicationQueriesSchemes` no `Info.plist` |

--- a/conductor/task/BUG-12-suporte-email.md
+++ b/conductor/task/BUG-12-suporte-email.md
@@ -1,0 +1,44 @@
+# BUG-12 — suporte - Direcionador para Email com Campo Pré-preenchido
+
+## Tela
+`lib/features/support/presentation/pages/support_page.dart` (ou onde o suporte está implementado)
+
+## Prioridade
+**Baixa** — melhoria de UX, não bloqueia nenhum fluxo crítico
+
+## Branch sugerida
+`fix/support-email-redirect`
+
+---
+
+## Melhoria
+
+### Botão de contato via email
+
+- [ ] **Implementar redirecionamento para app de email** ao tocar no botão/opção de suporte
+  - Usar `url_launcher` com esquema `mailto:` pré-configurado:
+    ```
+    mailto:suporte@reservaqui.com?subject=Suporte%20ReservAqui&body=Olá%2C%20preciso%20de%20ajuda%20com...
+    ```
+  - O `to` (email de destino do suporte) deve estar configurado como constante — não hardcodar espalhado pelo código
+  - O `subject` deve ser pré-preenchido com algo como "Suporte ReservAqui"
+  - O `body` pode ter um texto inicial opcional para guiar o usuário
+
+- [ ] Verificar se o pacote `url_launcher` já está nas dependências (`pubspec.yaml`) — se não, adicionar
+- [ ] Tratar o caso em que o dispositivo não tem app de email configurado: exibir um `SnackBar` com o endereço de email para o usuário copiar manualmente
+
+---
+
+## Arquivos a modificar
+
+| Arquivo | O que muda |
+|---------|-----------|
+| `support_page.dart` | Implementar lançamento do `mailto:` |
+| `pubspec.yaml` | Adicionar `url_launcher` se não existir |
+| Arquivo de constantes (ex: `app_constants.dart`) | Adicionar email de suporte como constante |
+
+---
+
+## Observações
+- Confirmar o endereço de email de suporte antes de implementar
+- No iOS, é necessário adicionar o scheme `mailto` ao `Info.plist` em `LSApplicationQueriesSchemes` para que `canLaunchUrl` funcione — verificar se já está configurado


### PR DESCRIPTION
## O que foi feito

Implementa o redirecionamento para app de email nativo ao tocar em "suporte" na tela de perfil do usuário. O `onTap` que era vazio agora abre um `mailto:` pré-configurado com destinatário, assunto e corpo. Caso o dispositivo não tenha app de email, exibe `SnackBar` com o endereço e botão de copiar.
Plan: `conductor/plans/suporte-email-redirect.plan.md`

## Arquivos criados

- `Frontend/lib/core/constants/app_constants.dart` — constante centralizada `supportEmail`
- `Frontend/lib/features/profile/presentation/pages/support_page.dart` — página de suporte acessível também via configurações
- `conductor/task/BUG-12-suporte-email.md` — task de referência
- `conductor/features/suporte-email-redirect.prd.md` — PRD da feature
- `conductor/specs/suporte-email-redirect.spec.md` — spec técnica
- `conductor/plans/suporte-email-redirect.plan.md` — plano de execução

## Arquivos modificados

- `Frontend/lib/features/profile/presentation/pages/user_profile_page.dart`
  - Conecta o `onTap` do item "suporte" ao fluxo `mailto:` com fallback `SnackBar`
- `Frontend/lib/features/profile/presentation/pages/settings_page.dart`
  - Adiciona tile "Suporte" na seção Legal, como segundo ponto de acesso
- `Frontend/lib/core/theme/app_colors.dart`
  - Adiciona `greyText` e `strokeLight` ausentes que causavam erro de compilação
- `Frontend/lib/core/widgets/custom_bottom_nav.dart`
  - Corrige import incorreto de `app_colors.dart` que causava erro de compilação
- `Frontend/ios/Runner/Info.plist`
  - Adiciona `LSApplicationQueriesSchemes: [mailto]` para permitir `canLaunchUrl` no iOS

## Checklist de validação

- [ ] Tocar no botão de email — verificar se abre o app de email com destinatário, assunto e corpo pré-preenchidos
- [ ] Simular dispositivo sem app de email — verificar se `SnackBar` exibe `reserv.aqui.123@gmail.com`
- [ ] Verificar no iOS que `canLaunchUrl` não é bloqueado após a alteração no `Info.plist`

🤖 Gerado com [Claude Code](https://claude.com/claude-code)