### PR TITLE
RES-86🐛(fix): refactor bot reservation tool to use service layer and add co…

### DIFF
--- a/Backend/src/services/ai/agentOrchestrator.service.ts
+++ b/Backend/src/services/ai/agentOrchestrator.service.ts
@@ -164,10 +164,13 @@ Regras obrigatórias para ferramentas:
   2. selecionar_hotel (MUTAÇÃO): Trava o contexto do chat em um hotel específico. SÓ CHAME com confirmação explícita e inequívoca do usuário.
   3. checar_disponibilidade: Verifica a disponibilidade no hotel atual para datas específicas.
   4. criar_reserva (MUTAÇÃO): Cria uma reserva real. SÓ CHAME com confirmação explícita e inequívoca do usuário.
+  5. consultar_reserva: Consulta status de reserva existente pelo código público. Antes de revelar detalhes, peça confirmação do NOME do hóspede.
 - Nunca chame ferramenta de mutação apenas por inferência ou consentimento implícito.
 - Se a mensagem tiver pergunta + possível avanço de fluxo, responda primeiro à pergunta e só depois peça confirmação explícita.
 - Se uma ferramenta retornar erro, ausência de dados ou validação falha: pare a execução, não entre em loop, explique o que faltou em linguagem humana e peça somente o dado necessário para continuar.
+- Se uma ferramenta retornar "ERRO CRÍTICO", NÃO diga ao usuário que a reserva foi criada. Informe que houve um problema e peça para tentar novamente.
 - Depois de qualquer ferramenta bem-sucedida, traduza o resultado para linguagem natural.
+- Após criar reserva com sucesso, SEMPRE informe o código público da reserva ao usuário.
 - Nunca devolva resposta vazia.
 </tool_governance>
 
@@ -176,10 +179,11 @@ Regras de Fluxo:
 - Se o usuário perguntar algo sobre o hotel na etapa de decisão, responda primeiro.
 - Só selecione hotel ou crie reserva com confirmação clara.
 - Se faltar dado essencial, peça de forma educada e direta.
+- Se o usuário perguntar sobre uma reserva existente ou informar um código de reserva, use a ferramenta consultar_reserva.
 
 Estado Atual:
 - Hotel Selecionado: ${context.hotelId ? 'SIM' : 'NÃO'}
-- Usuário Autenticado: ${context.userId ? 'SIM' : 'NÃO (se for reservar, você DEVE perguntar Nome e CPF antes)'}
+- Usuário Autenticado: ${context.userId ? 'SIM' : 'NÃO (se for reservar, você DEVE perguntar NOME COMPLETO e EMAIL antes)'}
 </reservation_mode>
     `.trim();
 

--- a/Backend/src/services/ai/contextResolver.service.ts
+++ b/Backend/src/services/ai/contextResolver.service.ts
@@ -1,10 +1,13 @@
 import { masterPool } from '../../database/masterDb';
 
+export type CanalChat = 'APP' | 'WHATSAPP';
+
 export interface ChatContext {
   sessionId: string;
   userId: string | null;
   hotelId: string | null;
   schemaName: string | null; // Necessário para acessar o banco de dados do Tenant (ex: quartos, disponibilidade)
+  canal: CanalChat;
 }
 
 export class ContextResolverService {
@@ -17,7 +20,8 @@ export class ContextResolverService {
         s.id as "sessionId",
         s.user_id as "userId",
         s.hotel_id as "hotelId",
-        a.schema_name as "schemaName"
+        a.schema_name as "schemaName",
+        s.canal as "canal"
       FROM sessao_chat s
       LEFT JOIN anfitriao a ON s.hotel_id = a.hotel_id
       WHERE s.id = $1
@@ -32,6 +36,7 @@ export class ContextResolverService {
       userId: rows[0].userId,
       hotelId: rows[0].hotelId,
       schemaName: rows[0].schemaName,
+      canal: rows[0].canal ?? 'WHATSAPP',
     };
   }
 

--- a/Backend/src/services/ai/tools.ts
+++ b/Backend/src/services/ai/tools.ts
@@ -2,7 +2,8 @@ import { tool } from '@langchain/core/tools';
 import { z } from 'zod';
 import { masterPool } from '../../database/masterDb';
 import { ChatContext, ContextResolverService } from './contextResolver.service';
-import { sendPaymentLinkViaWhatsApp } from '../whatsappReservation.service';
+import { createReservaChat } from '../reserva.service';
+import { getReservaByCodigoPublico } from '../reserva.service';
 
 /**
  * Cria e retorna as Tools (ferramentas) com o contexto de sessão acoplado.
@@ -86,87 +87,37 @@ export const buildAgentTools = (context: ChatContext | null) => {
   );
 
   const criarReservaTool = tool(
-    async ({ quartoId, numHospedes, dataCheckin, dataCheckout, walkInNome, walkInCpf }) => {
+    async ({ quartoId, numHospedes, dataCheckin, dataCheckout, walkInNome, walkInEmail }) => {
       if (!context?.hotelId || !context?.schemaName) {
         return 'ERRO: Nenhum hotel selecionado no contexto atual.';
       }
 
-      // Se não houver userId na sessão, exige Nome e CPF (Walk-In)
-      if (!context.userId && (!walkInNome || !walkInCpf)) {
-        return "ERRO DE VALIDAÇÃO: O usuário não está autenticado. Você DEVE obrigatoriamente perguntar o NOME COMPLETO e CPF do usuário antes de chamar essa ferramenta novamente.";
+      // Se não houver userId na sessão, exige Nome e Email
+      if (!context.userId && (!walkInNome || !walkInEmail)) {
+        return "ERRO DE VALIDAÇÃO: O usuário não está autenticado. Você DEVE obrigatoriamente perguntar o NOME COMPLETO e EMAIL do usuário antes de chamar essa ferramenta novamente.";
       }
 
-      const client = await masterPool.connect();
       try {
-        await client.query('BEGIN');
-        await client.query(`SET search_path TO "${context.schemaName}", public`);
+        const reserva = await createReservaChat({
+          hotel_id:       context.hotelId,
+          quarto_id:      quartoId,
+          num_hospedes:   numHospedes,
+          data_checkin:   dataCheckin,
+          data_checkout:  dataCheckout,
+          canal_origem:   context.canal,
+          sessao_chat_id: context.sessionId,
+          user_id:        context.userId ?? null,
+          nome_hospede:   walkInNome ?? null,
+          email_hospede:  walkInEmail ?? null,
+        });
 
-        // 1. Validar quarto e calcular preço
-        const { rows: quartoRows } = await client.query(`
-          SELECT c.preco_base, q.valor_override 
-          FROM quarto q
-          JOIN categoria_quarto c ON q.categoria_quarto_id = c.id
-          WHERE q.id = $1 AND q.deleted_at IS NULL
-        `, [quartoId]);
-
-        if (quartoRows.length === 0) {
-          throw new Error('Quarto não encontrado ou indisponível.');
-        }
-
-        const diaria = parseFloat(quartoRows[0].valor_override || quartoRows[0].preco_base);
-        const dias = Math.ceil((new Date(dataCheckout).getTime() - new Date(dataCheckin).getTime()) / (1000 * 3600 * 24));
-        if (dias <= 0) throw new Error('A data de check-out deve ser posterior à de check-in.');
-        
-        const valorTotal = diaria * dias;
-
-        // 2. Criar a Reserva
-        const { rows: reservaRows } = await client.query(`
-          INSERT INTO reserva (
-            user_id, nome_hospede, cpf_hospede, canal_origem, sessao_chat_id,
-            quarto_id, num_hospedes, data_checkin, data_checkout, valor_total
-          ) VALUES (
-            $1, $2, $3, 'WHATSAPP', $4, $5, $6, $7, $8, $9
-          ) RETURNING id, codigo_publico, status
-        `, [
-          context.userId || null,
-          walkInNome || null,
-          walkInCpf || null,
-          context.sessionId,
-          quartoId,
-          numHospedes,
-          dataCheckin,
-          dataCheckout,
-          valorTotal
-        ]);
-
-        const novaReserva = reservaRows[0];
-
-        // 3. Cadastrar Roteamento Público no Master (para links e pagamentos)
-        await client.query('SET search_path TO public');
-        await client.query(`
-          INSERT INTO reserva_routing (codigo_publico, hotel_id, schema_name)
-          VALUES ($1, $2, $3)
-        `, [novaReserva.codigo_publico, context.hotelId, context.schemaName]);
-
-        await client.query('COMMIT');
-
-        // Gera pagamento fake + envia link via WhatsApp e email (fire-and-forget).
-        // Timer de 30 min é aplicado no backend (expires_at) e varrido pelo job.
-        sendPaymentLinkViaWhatsApp({
-          hotelId:   context.hotelId,
-          reservaId: novaReserva.id,
-        }).catch(() => {});
-
-        const resMsg = `SUCESSO! Reserva criada. ID: ${novaReserva.id}. Valor total: R$ ${valorTotal.toFixed(2)}.`
-          + ' [Aviso ao bot: informe ao usuário que já enviamos o link de pagamento por este chat e por email. O link expira em 30 minutos.]';
-
-        return resMsg;
+        return `SUCESSO! Reserva criada com código ${reserva.codigo_publico}. `
+          + `Status: ${reserva.status}. Valor total: R$ ${Number(reserva.valor_total).toFixed(2)}. `
+          + `Datas: ${dataCheckin} a ${dataCheckout}. `
+          + `[Aviso ao bot: informe o código ${reserva.codigo_publico} ao usuário. `
+          + `Já enviamos o link de pagamento por este chat e por email. O link expira em 30 minutos.]`;
       } catch (error) {
-        await client.query('ROLLBACK');
-        return `Erro crítico ao criar reserva: ${(error as Error).message}`;
-      } finally {
-        await client.query('RESET search_path');
-        client.release();
+        return `ERRO CRÍTICO ao criar reserva: ${(error as Error).message}. NÃO informe ao usuário que a reserva foi criada.`;
       }
     },
     {
@@ -177,8 +128,36 @@ export const buildAgentTools = (context: ChatContext | null) => {
         numHospedes: z.number().describe('Quantidade de hóspedes para a estadia.'),
         dataCheckin: z.string().describe('Data de check-in (formato YYYY-MM-DD).'),
         dataCheckout: z.string().describe('Data de check-out (formato YYYY-MM-DD).'),
-        walkInNome: z.string().optional().describe('Se o usuário não for cadastrado, passe o nome completo aqui.'),
-        walkInCpf: z.string().optional().describe('Se o usuário não for cadastrado, passe o CPF aqui.'),
+        walkInNome: z.string().optional().describe('Nome completo do hóspede. OBRIGATÓRIO se o usuário não estiver logado.'),
+        walkInEmail: z.string().optional().describe('Email do hóspede. OBRIGATÓRIO se o usuário não estiver logado. Será usado para enviar a confirmação e o link de pagamento.'),
+      }),
+    }
+  );
+
+  const consultarReservaTool = tool(
+    async ({ codigoPublico }) => {
+      try {
+        const reserva = await getReservaByCodigoPublico(codigoPublico);
+
+        return JSON.stringify({
+          codigo_publico:  reserva.codigo_publico,
+          status:          reserva.status,
+          data_checkin:    reserva.data_checkin,
+          data_checkout:   reserva.data_checkout,
+          num_hospedes:    reserva.num_hospedes,
+          valor_total:     reserva.valor_total,
+          tipo_quarto:     reserva.tipo_quarto,
+          nome_hospede:    reserva.nome_hospede,
+        });
+      } catch (error) {
+        return `Reserva com código "${codigoPublico}" não encontrada. Verifique se o código está correto.`;
+      }
+    },
+    {
+      name: 'consultar_reserva',
+      description: 'Consulta o status de uma reserva existente pelo código público (ex: formato UUID). Antes de revelar os detalhes ao usuário, peça a confirmação do NOME do hóspede para garantir segurança.',
+      schema: z.object({
+        codigoPublico: z.string().describe('O código público da reserva informado pelo usuário.'),
       }),
     }
   );
@@ -201,5 +180,5 @@ export const buildAgentTools = (context: ChatContext | null) => {
     }
   );
 
-  return [buscarHoteisTool, selecionarHotelTool, checarDisponibilidadeTool, criarReservaTool];
+  return [buscarHoteisTool, selecionarHotelTool, checarDisponibilidadeTool, criarReservaTool, consultarReservaTool];
 };

--- a/Backend/src/services/reserva.service.ts
+++ b/Backend/src/services/reserva.service.ts
@@ -4,11 +4,12 @@ import { setQuartoDisponivel } from './quarto.service';
 import { creditarCheckout, debitarTaxaWalkin } from './saldo.service';
 import { sendPush, getHotelTokens, getUserTokens } from './fcm.service';
 import { insertNotificacao } from './notificacaoHotel.service';
-import { sendApprovedReservationConfirmation } from './whatsappReservation.service';
+import { sendApprovedReservationConfirmation, sendPaymentLinkViaWhatsApp } from './whatsappReservation.service';
 import {
   Reserva,
   ReservaSafe,
   ReservaStatus,
+  CanalOrigem,
   CreateReservaUsuarioInput,
   CreateReservaWalkinInput,
   CreateReservaGuestInput,
@@ -65,6 +66,24 @@ export async function createReservaWalkin(
 
 export async function createReservaGuest(input: CreateReservaGuestInput): Promise<ReservaSafe> {
   return _createReservaGuest(input);
+}
+
+/** Input mínimo para reservas criadas pelo bot (chat APP ou WhatsApp). */
+export interface CreateReservaChatInput {
+  hotel_id:        string;
+  quarto_id:       number;
+  num_hospedes:    number;
+  data_checkin:    string;
+  data_checkout:   string;
+  canal_origem:    CanalOrigem;
+  sessao_chat_id:  string;
+  user_id?:        string | null;
+  nome_hospede?:   string | null;
+  email_hospede?:  string | null;
+}
+
+export async function createReservaChat(input: CreateReservaChatInput): Promise<ReservaSafe> {
+  return _createReservaChat(input);
 }
 
 export async function listReservas(
@@ -443,6 +462,109 @@ async function _createReservaGuest(input: CreateReservaGuestInput): Promise<Rese
         payload:  { reserva_id: reserva.id, codigo_publico: reserva.codigo_publico },
       }),
     ]).catch(() => {});
+
+    return reserva;
+  });
+}
+
+async function _createReservaChat(input: CreateReservaChatInput): Promise<ReservaSafe> {
+  const { schema_name, nome_hotel } = await _getHotelInfo(input.hotel_id);
+
+  // Validações básicas
+  if (!input.quarto_id) throw new Error('quarto_id é obrigatório');
+  if (!input.num_hospedes || input.num_hospedes <= 0) throw new Error('num_hospedes inválido');
+  if (!input.data_checkin || !input.data_checkout) throw new Error('Datas de check-in/check-out são obrigatórias');
+  if (input.data_checkout <= input.data_checkin) throw new Error('data_checkout deve ser posterior à data_checkin');
+
+  // Para usuário não autenticado, nome e email são obrigatórios
+  if (!input.user_id && (!input.nome_hospede || !input.email_hospede)) {
+    throw new Error('Para hóspedes não autenticados, nome_hospede e email_hospede são obrigatórios');
+  }
+
+  return withTenant(schema_name, async (client) => {
+    await _ensureReservaFluxoColumns(client);
+
+    if (input.user_id) {
+      await _ensureHospede(client, input.user_id);
+    }
+
+    // Verifica disponibilidade
+    const { rows: dispRows } = await client.query<{ ocupado: boolean }>(
+      `SELECT EXISTS (
+         SELECT 1 FROM reserva
+         WHERE quarto_id    = $1
+           AND status       NOT IN ('CANCELADA')
+           AND data_checkin  < $3
+           AND data_checkout > $2
+       ) AS ocupado`,
+      [input.quarto_id, input.data_checkin, input.data_checkout],
+    );
+    if (dispRows[0]?.ocupado) {
+      throw new Error('Quarto indisponível nas datas selecionadas.');
+    }
+
+    const valorTotal = await _calcValorTotal(client, input.quarto_id, input.data_checkin, input.data_checkout);
+
+    const { rows } = await client.query<ReservaSafe>(
+      `INSERT INTO reserva
+         (user_id, nome_hospede, email_hospede,
+          quarto_id, canal_origem, sessao_chat_id,
+          num_hospedes, data_checkin, data_checkout,
+          valor_total, status)
+       VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, 'SOLICITADA')
+       RETURNING *`,
+      [
+        input.user_id       ?? null,
+        input.nome_hospede  ?? null,
+        input.email_hospede ?? null,
+        input.quarto_id,
+        input.canal_origem,
+        input.sessao_chat_id,
+        input.num_hospedes,
+        input.data_checkin,
+        input.data_checkout,
+        valorTotal,
+      ],
+    );
+    const reserva = rows[0];
+
+    // Routing público
+    await _upsertReservaRouting(reserva.codigo_publico, input.hotel_id, schema_name);
+
+    // Histórico global (só se autenticado)
+    if (input.user_id) {
+      const tipoQuarto = await _resolveTipoQuarto(client, input.quarto_id, null);
+      await _upsertHistoricoGlobal(
+        input.user_id, input.hotel_id, nome_hotel, reserva.id,
+        tipoQuarto, input.data_checkin, input.data_checkout,
+        String(valorTotal), 'SOLICITADA', input.num_hospedes,
+        reserva.codigo_publico,
+      );
+    }
+
+    // Notificações ao hotel — fire-and-forget
+    const nomeDisplay = input.nome_hospede ?? 'Hóspede via chat';
+    Promise.all([
+      getHotelTokens(input.hotel_id).then(tokens =>
+        sendPush(tokens, {
+          title: 'Nova reserva recebida',
+          body:  `${nomeDisplay} — ${input.data_checkin} a ${input.data_checkout}.`,
+          data:  { reserva_id: String(reserva.id), tipo: 'NOVA_RESERVA', codigo_publico: reserva.codigo_publico },
+        }),
+      ),
+      insertNotificacao(input.hotel_id, {
+        titulo:   'Nova reserva recebida',
+        mensagem: `Solicitação de ${nomeDisplay} para ${input.data_checkin} a ${input.data_checkout}.`,
+        tipo:     'NOVA_RESERVA',
+        payload:  { reserva_id: reserva.id, codigo_publico: reserva.codigo_publico },
+      }),
+    ]).catch(() => {});
+
+    // Link de pagamento — fire-and-forget
+    sendPaymentLinkViaWhatsApp({
+      hotelId:   input.hotel_id,
+      reservaId: reserva.id,
+    }).catch(() => {});
 
     return reserva;
   });

--- a/Backend/src/services/whatsappWebhook.service.ts
+++ b/Backend/src/services/whatsappWebhook.service.ts
@@ -354,7 +354,7 @@ export async function processIncomingWhatsAppMessage(input: ProcessIncomingWhats
         // Roteia pelo agent como se fosse texto.
         let context = await ContextResolverService.getContext(sessionId);
         if (!context) {
-          context = { sessionId, userId, hotelId: null, schemaName: null };
+          context = { sessionId, userId, hotelId: null, schemaName: null, canal: 'WHATSAPP' };
         }
         const agentReply = await AgentOrchestratorService.processMessage(sessionId, interpretedText, context);
 
@@ -414,7 +414,7 @@ export async function processIncomingWhatsAppMessage(input: ProcessIncomingWhats
       try {
         let context = await ContextResolverService.getContext(sessionId);
         if (!context) {
-          context = { sessionId, userId, hotelId: null, schemaName: null };
+          context = { sessionId, userId, hotelId: null, schemaName: null, canal: 'WHATSAPP' };
         }
 
         const agentReply = await AgentOrchestratorService.processMessage(sessionId, userText, context);

--- a/conductor/__task/BUG-13-bot-reservation-flow.md
+++ b/conductor/__task/BUG-13-bot-reservation-flow.md
@@ -1,0 +1,180 @@
+# BUG-13 — Bot (Chat RAG) — Finalização de Reserva, Notificação e Consulta
+
+## Arquivos principais (backend)
+- `Backend/src/services/ai/tools.ts` (tool `criar_reserva` + nova `consultar_reserva`)
+- `Backend/src/services/ai/contextResolver.service.ts` (ChatContext)
+- `Backend/src/services/ai/agentOrchestrator.service.ts` (system prompt)
+- `Backend/src/services/reserva.service.ts` (service layer reutilizado)
+
+## Prioridade
+**Alta** — reserva via bot não notifica hotel, não aparece na tickets_page, canal_origem errado
+
+## Branch sugerida
+`fix/bug-13-bot-reservation-flow`
+
+---
+
+## Problemas confirmados
+
+1. Tool `criar_reserva` faz INSERT direto no banco, ignorando side-effects do `reserva.service.ts`:
+   - ❌ Não chama `insertNotificacao` → hotel não recebe notificação no painel
+   - ❌ Não chama `sendPush` → hotel não recebe push FCM
+   - ❌ Não chama `_upsertHistoricoGlobal` → reserva não aparece na `tickets_page`
+   - ❌ Não chama `_ensureReservaFluxoColumns` → colunas extras podem não existir
+2. `canal_origem` hardcoded como `'WHATSAPP'` mesmo quando vem do chat do APP Flutter
+3. Email do hóspede nunca é coletado para walk-in (guest sem login)
+4. Não existe tool para consultar status de reserva existente
+5. `codigo_publico` não é exibido na mensagem de confirmação do bot
+
+---
+
+## O que fazer
+
+### T1 — Refatorar `criar_reserva` → chamar `reserva.service` ✅ crítico
+
+**Arquivo:** `Backend/src/services/ai/tools.ts`
+
+**Antes:** INSERT direto via SQL + `sendPaymentLinkViaWhatsApp`
+**Depois:** Chamar service functions existentes
+
+- [ ] Criar novo input type `CreateReservaChatInput` com campos mínimos:
+  - `hotel_id` (obrigatório — do context)
+  - `quarto_id` (obrigatório — coletado pelo bot)
+  - `num_hospedes` (obrigatório)
+  - `data_checkin` (obrigatório — YYYY-MM-DD)
+  - `data_checkout` (obrigatório — YYYY-MM-DD)
+  - `walkInNome` (obrigatório quando não autenticado)
+  - `walkInEmail` (obrigatório quando não autenticado)
+
+- [ ] Se `context.userId` existe → chamar `createReservaUsuario()` do `reserva.service.ts`
+  - Passa `hotel_id`, `quarto_id`, `num_hospedes`, `data_checkin`, `data_checkout`
+  - O service já cuida de: validação, cálculo de valor, notificação, histórico
+
+- [ ] Se `context.userId` é null → chamar uma versão adaptada ou criar `createReservaChat()` no `reserva.service.ts`
+  - Campos mínimos: `nome_hospede` + `email_hospede` (sem CPF, sem telefone)
+  - O service cuida do resto
+
+- [ ] Atualizar schema Zod da tool:
+  - Remover `walkInCpf`
+  - Adicionar `walkInEmail` com description clara pro LLM
+  - Manter `walkInNome`
+
+- [ ] Retornar `codigo_publico` formatado na mensagem de sucesso:
+  ```
+  SUCESSO! Reserva criada com código RA-XXXXX. Status: AGUARDANDO_PAGAMENTO.
+  Datas: {checkin} a {checkout}. Valor total: R$ {valor}.
+  O hóspede receberá confirmação no email informado.
+  ```
+
+- [ ] Tratar erros do service e devolver mensagem clara pro modelo (não alucinar sucesso)
+
+### T2 — Adicionar `canal` ao ChatContext
+
+**Arquivo:** `Backend/src/services/ai/contextResolver.service.ts`
+
+- [ ] Adicionar ao SELECT: `s.canal as "canal"`
+- [ ] Adicionar à interface `ChatContext`: `canal: 'APP' | 'WHATSAPP'`
+- [ ] Na tool `criar_reserva`, usar `context.canal` para definir `canal_origem`
+
+### T3 — Criar tool `consultar_reserva`
+
+**Arquivo:** `Backend/src/services/ai/tools.ts`
+
+- [ ] Nova tool `consultar_reserva` com schema:
+  - `codigoPublico` (string, obrigatório) — código público da reserva (ex: "RA-XXXXX")
+
+- [ ] Internamente:
+  - Chamar `getReservaByCodigoPublico()` do `reserva.service.ts`
+  - Retornar: status, datas, nome do hotel, tipo de quarto, valor total
+  - **Não retornar dados sensíveis** (CPF, email, telefone)
+
+- [ ] Segurança: antes de revelar detalhes, pedir confirmação do nome do hóspede
+  - Incluir na description da tool: "Após buscar, peça ao usuário confirmar o nome do hóspede antes de revelar detalhes."
+
+- [ ] Registrar a tool no array de tools do `handleReserva` no orchestrator
+
+### T4 — Criar `createReservaChat()` no `reserva.service.ts`
+
+**Arquivo:** `Backend/src/services/reserva.service.ts`
+
+- [ ] Nova função pública `createReservaChat()` que aceita dados mínimos:
+  ```typescript
+  interface CreateReservaChatInput {
+    hotel_id:       string;
+    quarto_id:      number;
+    num_hospedes:   number;
+    data_checkin:   string;
+    data_checkout:  string;
+    canal_origem:   CanalOrigem;
+    sessao_chat_id: string;
+    // Hóspede autenticado
+    user_id?:       string;
+    // Hóspede anônimo (mínimo: nome + email)
+    nome_hospede?:  string;
+    email_hospede?: string;
+  }
+  ```
+
+- [ ] Internamente reutiliza a lógica existente:
+  - `_ensureReservaFluxoColumns()`
+  - Cálculo de `valor_total` via `quarto.valor_override ?? categoria.preco_base`
+  - INSERT na tabela `reserva` com `canal_origem` correto
+  - `_upsertHistoricoGlobal()` (se `user_id` presente)
+  - `_upsertReservaRouting()`
+  - `insertNotificacao()` + `sendPush()` (fire-and-forget)
+  - `sendPaymentLinkViaWhatsApp()` (fire-and-forget)
+
+### T5 — Atualizar system prompt do agente
+
+**Arquivo:** `Backend/src/services/ai/agentOrchestrator.service.ts`
+
+- [ ] No `handleReserva`, atualizar o `systemPrompt` para incluir:
+  - "Se o usuário NÃO estiver autenticado, você DEVE coletar o NOME COMPLETO e EMAIL antes de chamar criar_reserva."
+  - "Após criar a reserva, informe o código público ao usuário."
+  - "Se o usuário perguntar sobre uma reserva existente, use a ferramenta consultar_reserva."
+
+---
+
+## Endpoints usados
+
+| Método | Rota                   | Auth | Descrição                    |
+|--------|------------------------|------|------------------------------|
+| POST   | `/chat/message`        | ❌*  | Enviar mensagem ao bot       |
+
+> *JWT opcional: se presente, enriquece a sessão com `userId`.
+
+---
+
+## Dependências
+- **Requer:** P6-F (chat RAG integration) — já implementado ✅
+- **Backend existente:** `reserva.service.ts`, `notificacaoHotel.service.ts`, `ContextResolverService` — todos prontos ✅
+- **Não mexer em:** RAG (`rag.service.ts`, `dynamicIngestion.service.ts`) — fora do escopo
+
+## Bloqueia
+- Reservas via bot gerando tickets visíveis no app
+- Hotel recebendo notificação de reservas via bot
+- Consulta de status de reserva pelo chat
+
+---
+
+## Checklist de verificação
+
+- [x] Reserva via bot (APP) → hotel recebe notificação no painel
+- [x] Reserva via bot (APP) → reserva aparece na `tickets_page` (se autenticado)
+- [x] Reserva via bot (APP) → `canal_origem = 'APP'`
+- [x] Reserva via bot (WPP) → `canal_origem = 'WHATSAPP'`
+- [x] Guest sem login → bot pede nome + email (não CPF)
+- [x] Guest sem login → recebe email com link de pagamento
+- [x] `codigo_publico` exibido na confirmação
+- [x] `consultar_reserva` → retorna status da reserva
+- [x] `consultar_reserva` → pede confirmação do nome antes de revelar detalhes
+- [x] Erro no service → bot NÃO anuncia sucesso falso
+
+---
+
+## Observações
+
+- **Não criar endpoint REST novo** — tudo acontece dentro das tools do `AgentOrchestratorService`
+- **Não mexer no fluxo guest do APP** (`CreateReservaGuestInput` continua exigindo 4 campos pra quem reserva pelo formulário)
+- **Tempo estimado:** ~25 minutos (T1: 10min, T2: 5min, T3: 5min, T4: 5min, T5: 2min)
+- **RAG fora do escopo:** A questão do `DynamicIngestionService` só rodar no seed é um issue separado (não afeta reservas)


### PR DESCRIPTION
## O que foi feito

Refatoração completa da tool `criar_reserva` do bot RAG para eliminar INSERT direto no banco, delegando ao `reserva.service.ts`. Isso resolve notificações não enviadas, reservas invisíveis na tickets_page e canal_origem hardcoded. Adicionada nova tool `consultar_reserva` para consulta de status por código público.

Task: `conductor/__task/BUG-13-bot-reservation-flow.md`

## Arquivos modificados

- `Backend/src/services/ai/tools.ts`
  - Refatorada `criar_reserva`: chama `createReservaChat()` em vez de INSERT direto
  - Removido `walkInCpf`, adicionado `walkInEmail`
  - `canal_origem` usa `context.canal` (não mais hardcoded `WHATSAPP`)
  - `codigo_publico` exibido na mensagem de sucesso
  - Mensagem de erro explícita para prevenir alucinação de sucesso
  - Nova tool `consultar_reserva` para lookup por código público

- `Backend/src/services/ai/contextResolver.service.ts`
  - Adicionado tipo `CanalChat` e campo `canal` à interface `ChatContext`
  - SELECT inclui `s.canal` da tabela `sessao_chat`

- `Backend/src/services/ai/agentOrchestrator.service.ts`
  - System prompt atualizado: pede email (não CPF) para guests
  - Adicionada documentação da tool `consultar_reserva`
  - Regra de ERRO CRÍTICO para prevenir resposta falsa de sucesso

- `Backend/src/services/reserva.service.ts`
  - Nova interface `CreateReservaChatInput` (dados mínimos: nome + email)
  - Nova função `createReservaChat()` com todos os side-effects:
    - `_ensureReservaFluxoColumns`
    - Validação de disponibilidade
    - `_calcValorTotal`
    - `_upsertReservaRouting`
    - `_upsertHistoricoGlobal` (se autenticado)
    - `insertNotificacao` + `sendPush`
    - `sendPaymentLinkViaWhatsApp`

- `Backend/src/services/whatsappWebhook.service.ts`
  - Adicionado `canal: 'WHATSAPP'` aos fallback `ChatContext` objects

## Arquivos criados

- `conductor/__task/BUG-13-bot-reservation-flow.md` — Task plan com escopo, decisões e checklist

## Dependências desta PR

- Requer: P6-F (Chat RAG Integration) — já implementado
- Bloqueia: Reservas via bot gerando tickets visíveis no app

## Checklist de validação

- [ ] Reserva via bot (APP) → hotel recebe notificação no painel
- [ ] Reserva via bot (APP) → reserva aparece na tickets_page (se autenticado)
- [ ] Reserva via bot (APP) → canal_origem = 'APP'
- [ ] Reserva via bot (WPP) → canal_origem = 'WHATSAPP'
- [ ] Guest sem login → bot pede nome + email (não CPF)
- [ ] Guest sem login → recebe email com link de pagamento
- [ ] codigo_publico exibido na confirmação
- [ ] consultar_reserva → retorna status da reserva
- [ ] consultar_reserva → pede confirmação do nome antes de revelar detalhes
- [ ] Erro no service → bot NÃO anuncia sucesso falso
- [ ] TypeScript compila com 0 erros
