### PR TITLE
🐛(fix): posiciona botão de notificação à direita no header da busca

### DIFF
--- a/Frontend/lib/features/search/presentation/pages/search_page.dart
+++ b/Frontend/lib/features/search/presentation/pages/search_page.dart
@@ -156,17 +156,14 @@ class _SearchPageState extends ConsumerState<SearchPage> {
                   height: 32,
                 ),
               ),
-              SizedBox(
-                width: 48,
-                child: Align(
-                  alignment: Alignment.centerRight,
-                  child: GestureDetector(
-                    onTap: () => context.push('/notifications'),
-                    child: Icon(
-                      Icons.notifications_none,
-                      color: colorScheme.onSurface,
-                      size: 28,
-                    ),
+              Align(
+                alignment: Alignment.centerRight,
+                child: GestureDetector(
+                  onTap: () => context.push('/notifications'),
+                  child: Icon(
+                    Icons.notifications_none,
+                    color: colorScheme.onSurface,
+                    size: 28,
                   ),
                 ),
               ),


### PR DESCRIPTION
## Summary
- Corrige o posicionamento do botão de notificação no header da tela de busca, que estava centralizado abaixo da logo em vez de encostar na borda direita.
- Substitui `SizedBox(width: 48)` com `Align.centerRight` (que ficava centralizado no `Stack` pai) por um `Align(alignment: Alignment.centerRight)` direto, que ocupa toda a largura do Stack.

## Test plan
- [ ] Abrir a tela de busca e confirmar que o ícone de notificação aparece à direita do header, alinhado verticalmente à logo central.
- [ ] Clicar no ícone e confirmar que ainda navega para `/notifications`.
- [ ] Verificar em tema claro e escuro.

🤖 Generated with [Claude Code](https://claude.com/claude-code)