### PR TITLE
🐛(fix): create documento_politica_hotel table on init_master

### DIFF
--- a/Backend/database/scripts/init_master.sql
+++ b/Backend/database/scripts/init_master.sql
@@ -235,3 +235,19 @@ CREATE TABLE IF NOT EXISTS documento_hotel (
 );
 
 CREATE INDEX IF NOT EXISTS idx_documento_hotel_id ON documento_hotel (hotel_id);
+
+-- 13. Documento de Política do Hotel
+--     Arquivo único (PDF, TXT ou MD) por hotel — substituído quando enviado de novo.
+--     Os arquivos salvos via POST /uploads/hotels/:hotel_id/policy são consumidos
+--     pelo RagService para responder perguntas sobre política do hotel no chatbot.
+--     Caminho físico: storage/hotels/:hotel_id/policies/
+CREATE TABLE IF NOT EXISTS documento_politica_hotel (
+    id              SERIAL          PRIMARY KEY,
+    hotel_id        UUID            NOT NULL REFERENCES anfitriao(hotel_id) ON DELETE CASCADE,
+    storage_path    TEXT            NOT NULL,
+    mime_type       TEXT            NOT NULL,
+    nome_arquivo    TEXT            NOT NULL,
+    criado_em       TIMESTAMPTZ     NOT NULL DEFAULT NOW(),
+    atualizado_em   TIMESTAMPTZ     NOT NULL DEFAULT NOW(),
+    UNIQUE (hotel_id)
+);


### PR DESCRIPTION
## O que foi feito

Adiciona a criação da tabela `documento_politica_hotel` ao `init_master.sql` para que o setup do banco a partir do zero (`docker compose down -v && up`) deixe o sistema apto a aceitar uploads de política de hotel sem erro.

## Contexto / motivação

A tabela `documento_politica_hotel` está definida em `Backend/src/database/migrations/20250505_create_documento_politica_hotel.sql`, mas o backend **não possui um migration runner** — esse arquivo nunca era aplicado automaticamente. O único script que roda no boot do Postgres é o `init_master.sql`, montado em `/docker-entrypoint-initdb.d/`.

Resultado: todo ambiente que faz reset do volume do banco (`down -v`) ficava sem essa tabela. Ao tentar salvar uma política pelo perfil do host, o INSERT em `policyUpload.controller.ts:166` falhava com `relation "documento_politica_hotel" does not exist` (código `42P01`), o backend devolvia 500 e o frontend mostrava "Erro ao processar arquivo".

Verificação no log do container reproduziu o erro:

\`\`\`
[uploadHotelPolicy] error: relation \"documento_politica_hotel\" does not exist
code: '42P01'
\`\`\`

## Arquivos modificados

- \`Backend/database/scripts/init_master.sql\`
  - Adicionado bloco \`CREATE TABLE IF NOT EXISTS documento_politica_hotel\` ao final do arquivo (após o bloco \`documento_hotel\`), com a mesma definição da migration original (\`id SERIAL PRIMARY KEY\`, \`hotel_id UUID FK ON DELETE CASCADE\`, \`storage_path\`, \`mime_type\`, \`nome_arquivo\`, \`criado_em\`, \`atualizado_em\`, \`UNIQUE (hotel_id)\`)

## Checklist de validação

- [ ] Após \`docker compose down -v && docker compose up --build\`, conferir com \`\d documento_politica_hotel\` no Postgres que a tabela foi criada
- [ ] Logado como host, anexar um arquivo \`.txt\` simples no perfil e clicar em salvar — upload retorna 201 sem erro
- [ ] Anexar um \`.pdf\` válido no perfil e salvar — upload retorna 201
- [ ] Tentar salvar de novo (substituindo a política existente) — upsert via \`ON CONFLICT (hotel_id)\` substitui o registro sem duplicar
- [ ] Verificar no log do backend que a mensagem \`relation \"documento_politica_hotel\" does not exist\` não aparece mais