### PR TITLE
⚙️(config): remove --omit=dev from backend npm install to allow tsc build

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -65,7 +65,7 @@ jobs:
       - name: 📦 Install backend dependencies
         run: |
           cd ${{ env.BACKEND_PATH }}
-          npm install --omit=dev
+          npm install
 
       - name: 🔨 Build backend
         run: |


### PR DESCRIPTION
## O que foi feito

Remoção da flag \--omit=dev\ do \
pm install\ no script de deploy do servidor. Isso garante que o Typescript (tsc) seja baixado e a compilação do Backend aconteça com sucesso no ambiente de Produção.

## Arquivos modificados

- \.github/workflows/deploy.yml\
  - \
pm install --omit=dev\ alterado para \
pm install\ no step de build do backend.

🤖 Gerado com Antigravity