### PR TITLE
fix(frontend): pass search query from home to search page via router

### DIFF
--- a/Frontend/lib/core/router/app_router.dart
+++ b/Frontend/lib/core/router/app_router.dart
@@ -105,7 +105,13 @@ final routerProvider = Provider<GoRouter>((ref) {
         routes: [
           GoRoute(
             path: '/search',
-            builder: (context, state) => const SearchPage(),
+            builder: (context, state) {
+              final extra = state.extra as Map<String, dynamic>? ?? {};
+              return SearchPage(
+                initialQuery: extra['query'] as String?,
+                initialAmenities: (extra['amenities'] as List?)?.cast<String>().toSet(),
+              );
+            },
           ),
           GoRoute(
             path: '/chat',


### PR DESCRIPTION
## Summary

- A rota `/search` instanciava `SearchPage()` sem parâmetros, descartando os dados enviados pela home
- O router agora extrai `state.extra` e repassa `initialQuery` e `initialAmenities` para o widget
- A busca é disparada automaticamente ao entrar na tela de busca com um termo

## Causa raiz

`app_router.dart` linha 108 usava `const SearchPage()` — o `extra` enviado via `context.push('/search', extra: {...})` nunca chegava ao widget.

## Test plan

- [x] Pesquisar um termo na barra da home e confirmar que a tela de busca abre com o campo preenchido
- [x] Confirmar que a busca é executada automaticamente ao entrar na tela
- [x] Confirmar que os filtros de amenities selecionados na home também são repassados
- [x] Acessar `/search` diretamente (sem `extra`) e confirmar que a tela abre normalmente sem erros

🤖 Generated with [Claude Code](https://claude.com/claude-code)