### PR TITLE
📝(docs): add context7 and linear mcp servers with setup guides

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -3,5 +3,9 @@
     "allow": [
       "Bash(mkdir:*)"
     ]
-  }
+  },
+  "enabledMcpjsonServers": [
+    "context7",
+    "linear"
+  ]
 }

--- a/.context/context7-mcp_context.md
+++ b/.context/context7-mcp_context.md
@@ -1,0 +1,165 @@
+# Context: Context7 MCP Server — ReservAqui
+
+> Last updated: 2026-05-11T00:00:00-03:00
+> Version: 1
+
+## Purpose
+
+Documentar a integração com o servidor MCP do **Context7** (`https://mcp.context7.com/mcp`) usado pelo Claude Code dentro do repositório ReservAqui. O Context7 fornece **documentação oficial e atualizada** de bibliotecas, frameworks, SDKs, CLIs e serviços de cloud diretamente para o agente — substituindo `WebSearch` para consultas de docs com mais precisão e velocidade.
+
+Cada desenvolvedor precisa apenas:
+1. Gerar uma API key em [context7.com](https://context7.com) (chave pessoal — formato `ctx7sk-...`).
+2. Exportar `CONTEXT7_API_KEY` como variável de ambiente do SO.
+3. Reiniciar o Claude Code dentro do projeto.
+
+O `.mcp.json` da raiz já está pronto e referencia `${CONTEXT7_API_KEY}` — **a chave nunca é commitada**.
+
+## Architecture / How It Works
+
+- **Transport:** HTTP (`type: "http"`) apontando para `https://mcp.context7.com/mcp` — não exige binário/runtime local, diferente de servidores `stdio`.
+- **Autenticação:** Header `CONTEXT7_API_KEY` enviado pelo Claude Code em cada chamada. O valor é interpolado de `${CONTEXT7_API_KEY}` no momento da inicialização do MCP — Claude lê a env var do processo pai (terminal/SO).
+- **Resolução de variável:** A interpolação `${VAR}` é feita pelo Claude Code, não pelo SO. O processo precisa **enxergar** a variável — daí a importância de exportar de forma persistente (`setx` no Windows ou `~/.bashrc`/`~/.zshrc` em Unix) e reabrir o terminal.
+- **Tools expostas:** Duas funções principais ficam disponíveis no Claude após a conexão:
+  - `mcp__context7__resolve-library-id` — converte um nome (ex.: `"React"`) em um ID Context7 (`/reactjs/react.dev`). Deve ser chamada antes de `query-docs`, exceto se o usuário já passar um ID no formato `/org/project`.
+  - `mcp__context7__query-docs` — busca a documentação na biblioteca resolvida com uma query específica. Limite recomendado: **3 chamadas por pergunta** do usuário.
+- **Quando usar:** Sintaxe de API, opções de configuração, migração entre versões, debug específico de uma lib, instruções de setup, uso de CLI. **Mesmo** quando o Claude acha que sabe — dados de treino podem estar desatualizados.
+- **Quando NÃO usar:** Refatoração, escrita de scripts do zero, debug de lógica de negócio do projeto, code review, conceitos gerais de programação. Para estes casos, o Claude opera com o contexto local.
+
+## Setup Guide (Obrigatório para novos desenvolvedores)
+
+### 1. Obter a API Key
+
+| Passo | Ação |
+|------|------|
+| 1.1 | Acessar [context7.com](https://context7.com) e fazer login (GitHub recomendado) |
+| 1.2 | Abrir o **Dashboard** → menu lateral **"API Keys"** |
+| 1.3 | Clicar em **"Create API Key"** — nome sugerido: `reservaqui-dev-<seu_nome>` |
+| 1.4 | Copiar a chave gerada (`ctx7sk-XXXXXXXX...`) — **a chave aparece apenas uma vez** |
+
+> A chave é pessoal. **Não commitar** no git, **não compartilhar** em chats. Se vazar, revogar imediatamente em **API Keys → Revoke** e gerar outra.
+
+### 2. Exportar a variável de ambiente
+
+#### 2.1 Windows
+
+**Opção A — Persistente (recomendado):**
+```powershell
+setx CONTEXT7_API_KEY "ctx7sk-cole-sua-chave-aqui"
+```
+> `setx` grava em `HKCU:\Environment` e só afeta **processos novos**. Feche todos os terminais e o Claude Code antes de testar.
+
+**Opção B — Sessão atual apenas:**
+```powershell
+$env:CONTEXT7_API_KEY = "ctx7sk-cole-sua-chave-aqui"
+```
+
+**Opção C — GUI:** `Win + R` → `sysdm.cpl` → aba **Avançado** → **Variáveis de Ambiente...** → **Variáveis de usuário** → **Novo...** → Nome: `CONTEXT7_API_KEY`, Valor: a chave.
+
+**Verificar (em terminal novo):**
+```powershell
+echo $env:CONTEXT7_API_KEY
+```
+
+#### 2.2 Linux / macOS
+
+Adicione no arquivo de config do shell em uso:
+
+```bash
+# Bash
+echo 'export CONTEXT7_API_KEY="ctx7sk-cole-sua-chave-aqui"' >> ~/.bashrc
+source ~/.bashrc
+
+# Zsh (padrão no macOS desde Catalina)
+echo 'export CONTEXT7_API_KEY="ctx7sk-cole-sua-chave-aqui"' >> ~/.zshrc
+source ~/.zshrc
+
+# Fish
+echo 'set -gx CONTEXT7_API_KEY "ctx7sk-cole-sua-chave-aqui"' >> ~/.config/fish/config.fish
+source ~/.config/fish/config.fish
+```
+
+> Descubra o shell em uso com `echo $SHELL`.
+
+**Verificar:**
+```bash
+echo $CONTEXT7_API_KEY
+```
+
+#### 2.3 Reiniciar o Claude Code
+
+Feche **completamente** o Claude Code (não basta abrir nova conversa) e reabra dentro do diretório do projeto. O `.mcp.json` é lido na inicialização.
+
+### 3. Verificação
+
+Peça ao Claude algo que dependa do Context7, ex.:
+
+> "Use o Context7 para buscar a doc atual de Server Components do React 19."
+
+O Claude deve chamar `mcp__context7__resolve-library-id` e depois `mcp__context7__query-docs`. Se aparecer **401/403**, a chave não está sendo enviada corretamente — revise a Parte 2.
+
+## Affected Project Files
+
+| File | Uses this system? | Relationship |
+|------|:-----------------:|--------------|
+| `.mcp.json` | Sim | Define o servidor `context7` (HTTP + header `CONTEXT7_API_KEY` interpolado da env). Único arquivo do repo que toca o MCP. |
+| `~/.bashrc` / `~/.zshrc` (Linux/Mac) | Sim (por dev) | Onde a env var deve ser exportada de forma persistente. **Fora do repo.** |
+| Variáveis de Usuário do Windows | Sim (por dev) | Onde o `setx` grava a chave. **Fora do repo.** |
+
+## Code Reference
+
+### `.mcp.json` — bloco `context7`
+
+```json
+{
+  "mcpServers": {
+    "context7": {
+      "type": "http",
+      "url": "https://mcp.context7.com/mcp",
+      "headers": {
+        "CONTEXT7_API_KEY": "${CONTEXT7_API_KEY}"
+      }
+    }
+  }
+}
+```
+
+**How it works:** Claude Code lê o arquivo na inicialização, interpola `${CONTEXT7_API_KEY}` com a env var do processo, e estabelece a conexão HTTP. Cada request a `mcp__context7__*` carrega o header.
+
+**Coupling / side-effects:** Sem a env var exportada, a interpolação resulta em string vazia → o servidor responde `401`. Sem o `.mcp.json`, as tools `mcp__context7__*` nem aparecem para o Claude.
+
+### Fluxo de uso típico
+
+```
+1. Usuário pergunta sobre React 19 Server Components
+2. Claude → mcp__context7__resolve-library-id("React")
+   → retorna ["/reactjs/react.dev", "/facebook/react", ...]
+3. Claude → mcp__context7__query-docs("/reactjs/react.dev", "Server Components in React 19")
+   → retorna trechos da doc oficial
+4. Claude responde ao usuário citando os trechos
+```
+
+## Key Design Decisions
+
+- **HTTP em vez de stdio:** O Context7 é um servidor remoto — não há binário local nem dependência Node/Python a instalar. Cada dev só precisa da env var.
+- **Interpolação `${CONTEXT7_API_KEY}` em vez de chave literal:** Mantém o `.mcp.json` commitável sem expor segredos. Cada dev cadastra a própria chave no SO. Mesma estratégia usada por `Backend/.env` para `WHATSAPP_TOKEN`, `GEMINI_API_KEY` e similares.
+- **Chave por dev (não compartilhada):** Permite revogação individual em caso de vazamento sem afetar o time. O dashboard do Context7 nomeia chaves (`reservaqui-dev-<nome>`) para facilitar auditoria.
+- **Persistente via `setx`/`~/.bashrc` em vez de `.env` do projeto:** O Claude Code é um processo global do SO — não roda no contexto do `Backend/` ou `Frontend/`. Por isso a env var precisa estar no nível do usuário/sistema, não em um `.env` local.
+- **Limite de 3 chamadas `query-docs` por pergunta:** Diretiva oficial do servidor Context7. Acima disso o Claude deve usar o melhor resultado obtido e seguir.
+
+## Troubleshooting
+
+| Sintoma | Causa provável | Solução |
+|---------|---------------|---------|
+| `401 Unauthorized` em chamadas Context7 | Chave inválida, revogada ou env var vazia | `echo` da var no terminal atual; gerar nova chave se necessário |
+| Tools `mcp__context7__*` não aparecem no Claude | Claude Code não foi reiniciado, ou está fora do diretório do projeto | Fechar Claude Code completamente e reabrir em `C:\Kellvin\desafio-final-ciclo\Reserva-Aqui---Projeto-de-fim-de-ciclo\` |
+| Variável aparece em um terminal mas não em outro | `setx`/`~/.bashrc` só afeta terminais novos | Fechar todos os terminais antigos; em macOS pode exigir logout/login |
+| `echo $env:CONTEXT7_API_KEY` vazio após `setx` | `setx` não afeta a sessão onde foi executado | Abrir uma janela nova de PowerShell |
+| Chave colada por engano no `.mcp.json` literal | Erro humano | Revogar imediatamente em [context7.com/dashboard](https://context7.com/dashboard) → API Keys → Revoke; gerar nova; voltar ao formato `${CONTEXT7_API_KEY}`; se já pushada, reescrever histórico |
+
+## Changelog
+
+### v1 — 2026-05-11
+- Servidor `context7` adicionado ao `.mcp.json` da raiz (HTTP em `https://mcp.context7.com/mcp`).
+- Header `CONTEXT7_API_KEY` configurado com interpolação `${CONTEXT7_API_KEY}` — chave **nunca** commitada.
+- Documentado fluxo completo de obtenção de chave em `context7.com`, exportação de env var em Windows (`setx`/`$env:`/GUI) e Linux/macOS (`~/.bashrc`/`~/.zshrc`/Fish), reinicialização do Claude Code e verificação.
+- Documentado limite de 3 chamadas `query-docs` por pergunta e os casos de uso recomendados (docs de libs/frameworks/CLIs) vs. proibidos (refator, lógica de negócio, code review).

--- a/.context/linear-mcp_context.md
+++ b/.context/linear-mcp_context.md
@@ -1,0 +1,194 @@
+# Context: Linear MCP Server — ReservAqui
+
+> Last updated: 2026-05-11T00:00:00-03:00
+> Version: 1
+
+## Purpose
+
+Documentar a integração com o servidor MCP oficial do **Linear** (`https://mcp.linear.app/mcp`) usado pelo Claude Code dentro do repositório ReservAqui. O Linear é o **issue tracker oficial** do projeto (prefixo de equipe `RES`), e o MCP permite ao Claude:
+
+- Criar, atualizar e fechar issues no Linear
+- Buscar issues por filtros (status, assignee, label, projeto)
+- Listar projetos, equipes e ciclos
+- Comentar em issues e mover entre estados (Backlog → In Progress → Done)
+- Auxiliar no fluxo de PR: ler descrição da issue, gerar nome de branch padrão (`res-<num>-<slug>`) e enriquecer commit/PR com referência à issue
+
+Cada desenvolvedor precisa apenas:
+1. Gerar uma Personal API key em **Linear → Settings → Account → Security & access** (formato `lin_api_...`).
+2. Exportar `LINEAR_API_KEY` como variável de ambiente do SO.
+3. Reiniciar o Claude Code dentro do projeto.
+
+O `.mcp.json` da raiz já está pronto e referencia `${LINEAR_API_KEY}` no header `Authorization: Bearer` — **a chave nunca é commitada**.
+
+## Architecture / How It Works
+
+- **Transport:** HTTP (`type: "http"`) apontando para `https://mcp.linear.app/mcp` — não exige binário/runtime local, igual ao Context7.
+- **Autenticação:** O servidor oficial suporta dois modos:
+  - **OAuth 2.1 com dynamic client registration** (modo padrão da CLI `claude mcp add`) — abre fluxo interativo no navegador.
+  - **Bearer token direto** — `Authorization: Bearer <token>` no header. Aceita Personal API keys (`lin_api_...`) ou OAuth tokens.
+  - Adotamos o **modo Bearer com Personal API key** porque é determinístico, não exige fluxo interativo a cada máquina e usa o mesmo padrão `${VAR}` do Context7. Cada dev gera a própria chave no Linear.
+- **Resolução de variável:** `${LINEAR_API_KEY}` é interpolado pelo Claude Code no momento da inicialização — o processo precisa **enxergar** a variável (daí a importância de exportar persistente via `setx` no Windows ou `~/.bashrc`/`~/.zshrc` em Unix e reabrir o terminal).
+- **Tools expostas:** Várias funções `mcp__linear__*` ficam disponíveis no Claude após a conexão (criar issue, atualizar, listar, comentar, etc.). A lista exata depende da versão do servidor — execute `/mcp` no Claude Code para ver as tools ativas.
+- **Padrão de branch:** As branches do projeto seguem `res-<numero>-<slug-em-kebab-case>` (lowercase), derivadas do ID da issue Linear. Exemplos do histórico do repo: `res-91-fix-chatbot-intent-routing-and-date-context`, `res-87-infra-deploy-automatico-via-github-actions-cicd`.
+
+## Setup Guide (Obrigatório para novos desenvolvedores)
+
+### 1. Obter a Personal API Key
+
+| Passo | Ação |
+|------|------|
+| 1.1 | Acessar [linear.app](https://linear.app) e fazer login na workspace do ReservAqui |
+| 1.2 | Abrir **Settings** (⚙️ canto inferior esquerdo) → **Account** → **Security & access** |
+| 1.3 | Rolar até **"Personal API keys"** → clicar em **"New API key"** |
+| 1.4 | Label sugerida: `reservaqui-claude-code-<seu_nome>` |
+| 1.5 | Copiar a chave gerada (`lin_api_XXXX...`) — **a chave aparece apenas uma vez** |
+
+> A chave é pessoal, vinculada ao seu usuário e herda **todas as suas permissões** na workspace. **Não commitar**, **não compartilhar**. Se vazar, revogar imediatamente em **Settings → Account → Security & access → Revoke** e gerar outra.
+
+### 2. Exportar a variável de ambiente
+
+#### 2.1 Windows
+
+**Opção A — Persistente (recomendado):**
+```powershell
+setx LINEAR_API_KEY "lin_api_cole-sua-chave-aqui"
+```
+> `setx` grava em `HKCU:\Environment` e só afeta **processos novos**. Feche todos os terminais e o Claude Code antes de testar.
+
+**Opção B — Sessão atual apenas:**
+```powershell
+$env:LINEAR_API_KEY = "lin_api_cole-sua-chave-aqui"
+```
+
+**Opção C — GUI:** `Win + R` → `sysdm.cpl` → aba **Avançado** → **Variáveis de Ambiente...** → **Variáveis de usuário** → **Novo...** → Nome: `LINEAR_API_KEY`, Valor: a chave.
+
+**Verificar (em terminal novo):**
+```powershell
+echo $env:LINEAR_API_KEY
+```
+
+#### 2.2 Linux / macOS
+
+Adicione no arquivo de config do shell em uso:
+
+```bash
+# Bash
+echo 'export LINEAR_API_KEY="lin_api_cole-sua-chave-aqui"' >> ~/.bashrc
+source ~/.bashrc
+
+# Zsh (padrão no macOS desde Catalina)
+echo 'export LINEAR_API_KEY="lin_api_cole-sua-chave-aqui"' >> ~/.zshrc
+source ~/.zshrc
+
+# Fish
+echo 'set -gx LINEAR_API_KEY "lin_api_cole-sua-chave-aqui"' >> ~/.config/fish/config.fish
+source ~/.config/fish/config.fish
+```
+
+> Descubra o shell em uso com `echo $SHELL`.
+
+**Verificar:**
+```bash
+echo $LINEAR_API_KEY
+```
+
+#### 2.3 Reiniciar o Claude Code
+
+Feche **completamente** o Claude Code e reabra dentro do diretório do projeto. O `.mcp.json` é lido na inicialização. Após reabrir, rode `/mcp` no chat para ver o servidor `linear` listado como `connected`.
+
+### 3. Verificação
+
+Peça ao Claude algo que dependa do Linear, ex.:
+
+> "Use o Linear MCP para listar minhas issues abertas no projeto ReservAqui."
+
+O Claude deve chamar `mcp__linear__*` (ou similar). Se aparecer **401/403**, a chave não está sendo enviada corretamente — revise a Parte 2.
+
+## Affected Project Files
+
+| File | Uses this system? | Relationship |
+|------|:-----------------:|--------------|
+| `.mcp.json` | Sim | Define o servidor `linear` (HTTP + header `Authorization: Bearer ${LINEAR_API_KEY}`). Único arquivo do repo que toca o MCP. |
+| `.claude/settings.local.json` | Sim | Lista `linear` em `enabledMcpjsonServers` para autorizar o servidor a rodar (sem isso o Claude pede permissão a cada sessão). |
+| `~/.bashrc` / `~/.zshrc` (Linux/Mac) | Sim (por dev) | Onde a env var deve ser exportada de forma persistente. **Fora do repo.** |
+| Variáveis de Usuário do Windows | Sim (por dev) | Onde o `setx` grava a chave. **Fora do repo.** |
+
+## Code Reference
+
+### `.mcp.json` — bloco `linear`
+
+```json
+{
+  "mcpServers": {
+    "linear": {
+      "type": "http",
+      "url": "https://mcp.linear.app/mcp",
+      "headers": {
+        "Authorization": "Bearer ${LINEAR_API_KEY}"
+      }
+    }
+  }
+}
+```
+
+**How it works:** Claude Code lê o arquivo na inicialização, interpola `${LINEAR_API_KEY}` com a env var do processo, e estabelece a conexão HTTP. Cada request a `mcp__linear__*` carrega o header `Authorization: Bearer lin_api_...`.
+
+**Coupling / side-effects:** Sem a env var exportada, a interpolação resulta em `Bearer ` (vazio) → o servidor responde `401`. Sem o `.mcp.json`, as tools `mcp__linear__*` nem aparecem para o Claude.
+
+### Convenção de branch
+
+Toda branch nova vinculada a uma issue do Linear segue:
+
+```
+res-<numero-da-issue>-<slug-em-kebab-case>
+```
+
+Exemplos reais do repo:
+- `res-91-fix-chatbot-intent-routing-and-date-context` → issue RES-91
+- `res-87-infra-deploy-automatico-via-github-actions-cicd` → issue RES-87
+
+Quando o Claude criar uma branch a partir de uma issue Linear, ele deve:
+1. Buscar a issue via MCP (título + descrição)
+2. Derivar o slug do título (lowercase, espaços → `-`, remover acentos/pontuação)
+3. Truncar para algo legível (~60 chars)
+
+### Fluxo de uso típico
+
+```
+1. Usuário pede: "Crie um card no Linear para X e abra a branch"
+2. Claude → mcp__linear__create_issue(team="RES", title="X", ...)
+   → retorna { identifier: "RES-118", title: "X", url: "..." }
+3. Claude → git checkout -b res-118-<slug-do-X>
+4. (após implementar) Claude → git commit / git push / gh pr create
+5. Claude → mcp__linear__update_issue(id="RES-118", state="In Review")
+```
+
+## Key Design Decisions
+
+- **HTTP em vez de stdio:** O Linear MCP é um servidor remoto oficial — não há binário local nem dependência Node/Python a instalar. Cada dev só precisa da env var. Mesmo princípio do Context7.
+- **Bearer com Personal API key, não OAuth interativo:** A doc do Linear sugere `claude mcp add --transport http linear-server https://mcp.linear.app/mcp` que faz OAuth, mas isso só é viável quando o `.mcp.json` é por-dev. Como o nosso `.mcp.json` é commitado e compartilhado, usamos Personal API key via `${LINEAR_API_KEY}` — cada dev gera a própria chave, segue o mesmo padrão do Context7, e a credencial nunca toca o repo.
+- **Chave por dev (não compartilhada):** A Personal API key herda as permissões do usuário no Linear — auditoria nativa (toda ação criada pelo MCP fica em nome do dev correto). Permite revogação individual em caso de vazamento.
+- **Persistente via `setx`/`~/.bashrc` em vez de `.env` do projeto:** O Claude Code é um processo global do SO — não roda no contexto do `Backend/` ou `Frontend/`. A env var precisa estar no nível do usuário/sistema, não em um `.env` local carregado por dotenv.
+- **Padrão `res-<num>-<slug>` para branches:** Já é convenção do time observada no histórico do repo. Garante rastreabilidade direta entre git e Linear sem campos extras.
+
+## Troubleshooting
+
+| Sintoma | Causa provável | Solução |
+|---------|---------------|---------|
+| `401 Unauthorized` em chamadas Linear | Chave inválida, revogada, ou env var vazia | `echo` da var no terminal atual; gerar nova chave em **Settings → Account → Security & access** |
+| `403 Forbidden` em ações específicas (criar issue, mover state) | Personal API key herda permissões do usuário — ação fora do escopo da workspace dele | Confirmar que o usuário tem permissão manual na UI; promover papel se necessário |
+| Tools `mcp__linear__*` não aparecem no Claude | Claude Code não foi reiniciado, fora do diretório do projeto, ou `linear` não está em `enabledMcpjsonServers` | Reiniciar Claude Code; rodar `/mcp` para ver status; conferir `.claude/settings.local.json` |
+| Variável aparece em um terminal mas não em outro | `setx`/`~/.bashrc` só afeta terminais novos | Fechar todos os terminais antigos; em macOS pode exigir logout/login |
+| `echo $env:LINEAR_API_KEY` vazio após `setx` | `setx` não afeta a sessão onde foi executado | Abrir uma janela nova de PowerShell |
+| Chave colada por engano no `.mcp.json` literal | Erro humano | Revogar em **Linear → Settings → Account → Security & access → Revoke**; gerar nova; voltar ao formato `${LINEAR_API_KEY}`; se já pushada, reescrever histórico |
+| `/mcp` mostra `linear` mas todas as tools falham com timeout | Workspace pode não ter o app MCP habilitado | Workspace admin precisa autorizar o Linear MCP em **Settings → Workspace → Integrations** |
+
+## Changelog
+
+### v1 — 2026-05-11
+- Servidor `linear` adicionado ao `.mcp.json` da raiz (HTTP em `https://mcp.linear.app/mcp`).
+- Header `Authorization` configurado com interpolação `Bearer ${LINEAR_API_KEY}` — chave **nunca** commitada.
+- `linear` adicionado a `.claude/settings.local.json → enabledMcpjsonServers` para auto-permissão na sessão.
+- Documentado fluxo completo de obtenção de Personal API key em `linear.app → Settings → Account → Security & access`, exportação de env var em Windows (`setx`/`$env:`/GUI) e Linux/macOS (`~/.bashrc`/`~/.zshrc`/Fish), reinicialização do Claude Code e verificação via `/mcp`.
+- Documentada a convenção `res-<num>-<slug>` de branches já em uso no repo (observada em `git log`).
+- Decisão: Bearer com Personal API key em vez do OAuth interativo da CLI `claude mcp add`, para manter `.mcp.json` commitável e cada dev com auditoria nativa via sua própria chave.

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,18 @@
+{
+  "mcpServers": {
+    "context7": {
+      "type": "http",
+      "url": "https://mcp.context7.com/mcp",
+      "headers": {
+        "CONTEXT7_API_KEY": "${CONTEXT7_API_KEY}"
+      }
+    },
+    "linear": {
+      "type": "http",
+      "url": "https://mcp.linear.app/mcp",
+      "headers": {
+        "Authorization": "Bearer ${LINEAR_API_KEY}"
+      }
+    }
+  }
+}


### PR DESCRIPTION
## O que foi feito

Habilitação dos servidores MCP **Context7** (docs de bibliotecas/frameworks) e **Linear** (issue tracker do projeto) no Claude Code via `.mcp.json` na raiz, mais a documentação completa de setup para cada dev em `.context/` no padrão dos demais arquivos `_context.md` do projeto.

Sem código de aplicação alterado — apenas configuração de tooling do Claude e docs.

## Arquivos criados

- `.mcp.json` — registra os dois servidores MCP (HTTP) com credenciais interpoladas via `${CONTEXT7_API_KEY}` e `Bearer ${LINEAR_API_KEY}`. Chaves nunca commitadas.
- `.context/context7-mcp_context.md` — guia completo do Context7 (Purpose / Architecture / Setup / Affected Files / Code Reference / Key Design Decisions / Troubleshooting / Changelog) com instruções de export da env var em Windows (`setx` / GUI) e Linux/macOS (`~/.bashrc` / `~/.zshrc` / Fish).
- `.context/linear-mcp_context.md` — mesma estrutura para o Linear MCP. Documenta Personal API key (`lin_api_...`) em **Linear → Settings → Account → Security & access**, fluxo de uso típico (criar issue → branch `res-<num>-<slug>` → commit → PR → atualizar state) e a convenção de branch já em uso no repo.

## Arquivos modificados

- `.claude/settings.local.json`
  - Adicionado bloco `enabledMcpjsonServers: ["context7", "linear"]` para auto-permissão dos servidores na sessão.

## Decisões de design relevantes

- **HTTP em vez de stdio:** ambos os servidores são oficiais e remotos — sem binário local nem dependência Node/Python a instalar.
- **Bearer com Personal API key (Linear) em vez de OAuth interativo:** mantém o `.mcp.json` commitável e compartilhável; cada dev gera a própria chave e ações ficam auditadas em nome do dev correto.
- **Env vars no SO (não em `.env` do Backend):** o Claude Code é processo do SO, não da app Node. As chaves vivem em `setx` (Windows) / `~/.bashrc` ou `~/.zshrc` (Linux/macOS) — não foram adicionadas ao `Backend/.env.example` pra não criar a falsa expectativa de que basta preencher o `.env` do dotenv.
- **Padrão de branch documentado:** `res-<num>-<slug>` derivado do ID da issue Linear, reforçando a convenção já observada no `git log` (RES-91, RES-87 etc.).

## Checklist de validação

- [ ] `echo \$CONTEXT7_API_KEY` (Linux/Mac) ou `echo \$env:CONTEXT7_API_KEY` (Windows) retorna a chave em terminal novo
- [ ] `echo \$LINEAR_API_KEY` retorna a chave em terminal novo
- [ ] Após reiniciar Claude Code dentro do projeto, `/mcp` lista `context7` e `linear` como `connected`
- [ ] `mcp__context7__resolve-library-id("React")` retorna resultados sem 401/403
- [ ] `mcp__linear__*` (criar/listar issue) retorna resultado válido sem 401/403
- [ ] `.mcp.json` não contém chave literal — apenas `${CONTEXT7_API_KEY}` e `${LINEAR_API_KEY}`