### PR TITLE
🐛(fix): add missing fotoUrl field to AdminHotelDTO test mock

### DIFF
--- a/Backend/src/routes/__tests__/admin.routes.test.ts
+++ b/Backend/src/routes/__tests__/admin.routes.test.ts
@@ -72,6 +72,7 @@ const sampleHotel: AdminHotelDTO = {
   numero:           '1000',
   complemento:      null,
   capaUrl:          null,
+  fotoUrl:          null,
   status:           'ativo',
   totalQuartos:     null,
   criadoEm:         '2026-01-01T00:00:00.000Z',


### PR DESCRIPTION
## O que foi feito

O campo otoUrl foi adicionado ao tipo AdminHotelDTO em dmin.service.ts, mas o objeto mock sampleHotel no arquivo de testes não foi atualizado junto, causando falha de build no CI/CD com o erro:

`
error TS2741: Property 'fotoUrl' is missing in type '{...}' but required in type 'AdminHotelDTO'
`

Closes RES-92

## Arquivos modificados

- `Backend/src/routes/__tests__/admin.routes.test.ts`
  - Adicionado campo `fotoUrl: null` ao mock `sampleHotel` para satisfazer o contrato do tipo `AdminHotelDTO`

## Checklist de validação

- [ ] `npm run build` passa sem erros de TypeScript
- [ ] CI/CD do GitHub Actions conclui o step de build com sucesso
- [ ] Nenhum teste existente quebrado pela mudança

🤖 Gerado com [Claude Code](https://claude.com/claude-code)