### PR TITLE
fix: host notifications infinite loading, support mailto and notification tap navigation

### DIFF
--- a/Frontend/lib/features/notifications/data/services/notificacoes_host_service.dart
+++ b/Frontend/lib/features/notifications/data/services/notificacoes_host_service.dart
@@ -8,8 +8,9 @@ class NotificacoesHostService {
   final Dio _dio;
 
   Future<List<AppNotification>> fetchAll() async {
-    final response = await _dio.get<List<dynamic>>('/hotel/notificacoes');
-    return (response.data ?? [])
+    final response = await _dio.get<Map<String, dynamic>>('/hotel/notificacoes');
+    final list = (response.data?['data'] as List<dynamic>?) ?? [];
+    return list
         .map((e) => AppNotification.fromJson(e as Map<String, dynamic>))
         .toList();
   }

--- a/Frontend/lib/features/notifications/presentation/pages/notifications_page.dart
+++ b/Frontend/lib/features/notifications/presentation/pages/notifications_page.dart
@@ -66,73 +66,82 @@ class NotificationsPage extends ConsumerWidget {
   }
 
 
+  String? _parseDates(String text) {
+    final matches = RegExp(r'\d{4}-\d{2}-\d{2}').allMatches(text).toList();
+    if (matches.isEmpty) return null;
+    String fmt(String iso) {
+      final p = iso.split('-');
+      return '${p[2]}/${p[1]}';
+    }
+    if (matches.length >= 2) {
+      return '${fmt(matches[0].group(0)!)} → ${fmt(matches[1].group(0)!)}';
+    }
+    return fmt(matches[0].group(0)!);
+  }
+
+  void _handleNotificationTap(
+    WidgetRef ref,
+    BuildContext context,
+    AppNotification notification,
+  ) {
+    ref.read(notificationsProvider.notifier).markAsRead(notification.id);
+    _navigateFromNotification(context, notification);
+  }
+
   Widget _buildNotificationCard(
     BuildContext context,
     WidgetRef ref,
     AppNotification notification,
   ) {
     final colorScheme = Theme.of(context).colorScheme;
-    return Container(
-      padding: const EdgeInsets.all(16),
-      decoration: BoxDecoration(
-        color: colorScheme.surface,
-        borderRadius: BorderRadius.circular(11),
-        border: Border.all(
-          color: notification.isRead
-              ? colorScheme.outline
-              : colorScheme.primary.withValues(alpha: 0.4),
+    final dates = _parseDates(notification.subtitle);
+    return InkWell(
+      onTap: () => _handleNotificationTap(ref, context, notification),
+      borderRadius: BorderRadius.circular(11),
+      child: Container(
+        padding: const EdgeInsets.all(16),
+        decoration: BoxDecoration(
+          color: colorScheme.surface,
+          borderRadius: BorderRadius.circular(11),
+          border: Border.all(
+            color: notification.isRead
+                ? colorScheme.outline
+                : colorScheme.primary.withValues(alpha: 0.4),
+          ),
         ),
-      ),
-      child: Row(
-        children: [
-          Expanded(
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                Row(
-                  children: [
-                    if (!notification.isRead)
-                      Container(
-                        width: 7,
-                        height: 7,
-                        margin: const EdgeInsets.only(right: 6),
-                        decoration: const BoxDecoration(
-                          color: Colors.red,
-                          shape: BoxShape.circle,
+        child: Row(
+          children: [
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Row(
+                    children: [
+                      if (!notification.isRead)
+                        Container(
+                          width: 7,
+                          height: 7,
+                          margin: const EdgeInsets.only(right: 6),
+                          decoration: const BoxDecoration(
+                            color: Colors.red,
+                            shape: BoxShape.circle,
+                          ),
+                        ),
+                      Flexible(
+                        child: Text(
+                          notification.title,
+                          style: TextStyle(
+                            color: colorScheme.onSurface,
+                            fontSize: 14,
+                            fontWeight: FontWeight.w700,
+                          ),
                         ),
                       ),
-                    Flexible(
-                      child: Text(
-                        notification.title,
-                        style: TextStyle(
-                          color: colorScheme.onSurface,
-                          fontSize: 14,
-                          fontWeight: FontWeight.w700,
-                        ),
-                      ),
-                    ),
-                    const SizedBox(width: 8),
-                    GestureDetector(
-                      onTap: () {
-                        ref
-                            .read(notificationsProvider.notifier)
-                            .markAsRead(notification.id);
-                        _navigateFromNotification(context, notification);
-                      },
-                      child: const Text(
-                        'ver detalhes',
-                        style: TextStyle(
-                          color: AppColors.secondary,
-                          fontSize: 14,
-                          fontWeight: FontWeight.w700,
-                        ),
-                      ),
-                    ),
-                  ],
-                ),
+                    ],
+                  ),
                 const SizedBox(height: 4),
                 Text(
-                  notification.subtitle,
+                  dates ?? notification.subtitle,
                   style: TextStyle(
                     color: colorScheme.onSurfaceVariant,
                     fontSize: 12,
@@ -155,6 +164,7 @@ class NotificationsPage extends ConsumerWidget {
           ),
         ],
       ),
+    ),
     );
   }
 

--- a/Frontend/lib/features/notifications/presentation/providers/notifications_provider.dart
+++ b/Frontend/lib/features/notifications/presentation/providers/notifications_provider.dart
@@ -9,7 +9,7 @@ class NotificationsNotifier
     extends AsyncNotifier<List<AppNotification>> {
   @override
   Future<List<AppNotification>> build() async {
-    final auth = await ref.watch(authProvider.future);
+    final auth = await ref.read(authProvider.future);
     if (!auth.isAuthenticated) return [];
 
     if (auth.role == AuthRole.host) {

--- a/Frontend/lib/features/profile/presentation/pages/admin_profile_page.dart
+++ b/Frontend/lib/features/profile/presentation/pages/admin_profile_page.dart
@@ -1,7 +1,10 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart' show Clipboard, ClipboardData;
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
+import 'package:url_launcher/url_launcher.dart' show launchUrl;
 import '../../../../core/auth/auth_notifier.dart';
+import '../../../../core/constants/app_constants.dart';
 import '../../../../core/theme/app_colors.dart';
 import '../../../../core/utils/string_extensions.dart';
 import '../../../../core/widgets/primary_button.dart';
@@ -66,7 +69,34 @@ class AdminProfilePage extends ConsumerWidget {
                     ProfileMenuItem(
                       title: 'Suporte',
                       icon: Icons.headset_mic_outlined,
-                      onTap: () {},
+                      onTap: () async {
+                        final uri = Uri(
+                          scheme: 'mailto',
+                          path: AppConstants.supportEmail,
+                          queryParameters: {
+                            'subject': 'Suporte ReservAqui',
+                            'body': 'Olá, preciso de ajuda com...',
+                          },
+                        );
+                        try {
+                          await launchUrl(uri);
+                        } catch (_) {
+                          if (!context.mounted) return;
+                          ScaffoldMessenger.of(context).showSnackBar(
+                            SnackBar(
+                              content: Text(
+                                  'Copie o email: ${AppConstants.supportEmail}'),
+                              action: SnackBarAction(
+                                label: 'Copiar',
+                                onPressed: () => Clipboard.setData(
+                                  ClipboardData(
+                                      text: AppConstants.supportEmail),
+                                ),
+                              ),
+                            ),
+                          );
+                        }
+                      },
                       showDivider: false,
                     ),
                   ],

--- a/Frontend/lib/features/profile/presentation/pages/host_profile_page.dart
+++ b/Frontend/lib/features/profile/presentation/pages/host_profile_page.dart
@@ -1,7 +1,10 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart' show Clipboard, ClipboardData;
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
+import 'package:url_launcher/url_launcher.dart' show launchUrl;
 import '../../../../core/auth/auth_notifier.dart';
+import '../../../../core/constants/app_constants.dart';
 import '../../../../core/theme/app_colors.dart';
 import '../../../../core/utils/string_extensions.dart';
 import '../../../../core/widgets/primary_button.dart';
@@ -112,7 +115,34 @@ class HostProfilePage extends ConsumerWidget {
                       ProfileMenuItem(
                         title: 'Suporte',
                         icon: Icons.headset_mic_outlined,
-                        onTap: () {},
+                        onTap: () async {
+                          final uri = Uri(
+                            scheme: 'mailto',
+                            path: AppConstants.supportEmail,
+                            queryParameters: {
+                              'subject': 'Suporte ReservAqui',
+                              'body': 'Olá, preciso de ajuda com...',
+                            },
+                          );
+                          try {
+                            await launchUrl(uri);
+                          } catch (_) {
+                            if (!context.mounted) return;
+                            ScaffoldMessenger.of(context).showSnackBar(
+                              SnackBar(
+                                content: Text(
+                                    'Copie o email: ${AppConstants.supportEmail}'),
+                                action: SnackBarAction(
+                                  label: 'Copiar',
+                                  onPressed: () => Clipboard.setData(
+                                    ClipboardData(
+                                        text: AppConstants.supportEmail),
+                                  ),
+                                ),
+                              ),
+                            );
+                          }
+                        },
                         showDivider: false,
                       ),
                     ],


### PR DESCRIPTION
## Summary

- **Notificações host em loop infinito**: `ref.watch` → `ref.read` em `NotificationsNotifier.build()` para quebrar o ciclo reativo com o interceptor de refresh de token; corrige também o parsing da resposta `{ data: [...] }` do backend em `NotificacoesHostService.fetchAll()`
- **Botão Suporte sem ação**: implementa `launchUrl(mailto:)` com fallback de snackbar + copiar email em `HostProfilePage` e `AdminProfilePage` (estava com `onTap: () {}` vazio)
- **Cards de notificação tappáveis**: envolve cada card em `InkWell` para que qualquer toque navegue para a página correta (ticket, chat, checkout externo); extrai `_handleNotificationTap` helper; adiciona `_parseDates` que extrai datas ISO do texto e as exibe como `dd/MM → dd/MM` na segunda linha do card

## Test plan

- [x] Abrir notificações como **host** — não deve ficar em loading infinito
- [x] Apertar em card de notificação `NOVA_RESERVA` → deve navegar para `TicketDetailsPage`
- [x] Apertar em card `MENSAGEM_CHAT` → deve ir para `/chat`
- [ ] Card de `NOVA_RESERVA` deve exibir datas de check-in/checkout abaixo do título
- [ ] Cards sem datas (MENSAGEM_CHAT, PAGAMENTO_CONFIRMADO) devem exibir o texto original
- [x] Botão **Suporte** no perfil do host → deve abrir app de email com mailto
- [x] Botão **Suporte** no perfil do admin → mesmo comportamento
- [x] Tap numa notificação deve marcar ela como lida (ponto vermelho some)

🤖 Generated with [Claude Code](https://claude.com/claude-code)