### PR TITLE
🐛(fix): aplica guardrail obrigatório no RAG e corrige chunking Markdown (RES-95)

### DIFF
--- a/Backend/src/controllers/policyUpload.controller.ts
+++ b/Backend/src/controllers/policyUpload.controller.ts
@@ -27,7 +27,15 @@ function isPdfMagicBytes(filePath: string): boolean {
  * quebras de parágrafo. Retorna array vazio se o conteúdo for vazio.
  */
 function chunkText(text: string, maxChars = 800): string[] {
-  const paragraphs = text
+  // Normaliza Markdown: garante dupla quebra antes de headers e itens de lista,
+  // para que cada seção vire um chunk semântico independente.
+  const normalized = text
+    .replace(/\r\n/g, '\n')
+    .replace(/\n(#{1,6}\s)/g, '\n\n$1')       // # Headers
+    .replace(/\n([-*]\s)/g, '\n\n$1')          // - * listas
+    .replace(/\n(\d+\.\s)/g, '\n\n$1');        // 1. listas numeradas
+
+  const paragraphs = normalized
     .split(/\n{2,}/)
     .map((p) => p.trim())
     .filter((p) => p.length > 0);

--- a/Backend/src/services/ai/agentOrchestrator.service.ts
+++ b/Backend/src/services/ai/agentOrchestrator.service.ts
@@ -165,12 +165,17 @@ ${ragContext}
     const tools = buildAgentTools(context);
     const cidadesDisponiveis = await this.getCidadesDisponiveis();
 
-    // Se há hotel selecionado, busca contexto RAG para evitar alucinações em perguntas de política
+    // RAG obrigatório: injeta guardrail sempre que há hotel selecionado.
+    // Se não houver documentos indexados, injeta bloco restritivo para impedir alucinação.
     let ragSection = '';
     if (context.hotelId) {
       try {
         const ragContext = await RagService.searchRelevantContext(userMessage, context.hotelId);
-        if (ragContext && !ragContext.startsWith('Nenhum documento') && !ragContext.startsWith('Erro')) {
+        const hasContent = ragContext
+          && !ragContext.startsWith('Nenhum documento')
+          && !ragContext.startsWith('Erro');
+
+        if (hasContent) {
           ragSection = `
 <hotel_knowledge_base>
 Use EXCLUSIVAMENTE estas informações para responder dúvidas sobre políticas, regras, comodidades e serviços do hotel selecionado.
@@ -178,9 +183,22 @@ Não invente informações que não estejam aqui. Se a informação não estiver
 
 ${ragContext}
 </hotel_knowledge_base>`;
+        } else {
+          // Guardrail restritivo: sem documentos → proíbe explicitamente inventar dados do hotel.
+          ragSection = `
+<hotel_knowledge_base>
+Nenhuma política ou informação de comodidades foi indexada para este hotel ainda.
+NÃO invente check-in, check-out, aceite de pets, Wi-Fi, piscina, restaurante ou qualquer outra comodidade/regra.
+Se perguntado sobre políticas ou serviços do hotel, informe educadamente que o hotel ainda não disponibilizou esse detalhamento na plataforma e sugira contato direto com a recepção.
+</hotel_knowledge_base>`;
         }
       } catch (e) {
-        console.warn('[AgentOrchestrator] Falha ao buscar RAG no fluxo RESERVA (continuando sem):', e);
+        console.warn('[AgentOrchestrator] Falha ao buscar RAG no fluxo RESERVA:', e);
+        // Mesmo em caso de erro técnico, injeta guardrail mínimo.
+        ragSection = `
+<hotel_knowledge_base>
+Não foi possível recuperar políticas do hotel no momento. Não invente informações. Sugira contato com a recepção.
+</hotel_knowledge_base>`;
       }
     }
 

--- a/Backend/src/services/ai/rag.service.ts
+++ b/Backend/src/services/ai/rag.service.ts
@@ -2,7 +2,7 @@ import { GoogleGenerativeAIEmbeddings } from '@langchain/google-genai';
 import { masterPool } from '../../database/masterDb';
 
 // ── Configuração do RAG Pipeline ──────────────────────────────────────────────
-const RAG_MIN_RELEVANCE_SCORE = 0.70;   // Score mínimo para considerar documento relevante
+const RAG_MIN_RELEVANCE_SCORE = 0.55;   // Score mínimo para considerar documento relevante (chunks de política .md tendem a scores mais baixos)
 const RAG_TOP_K_DOCS          = 5;      // Máximo de documentos recuperados por busca
 const RAG_MAX_DOC_CONTENT_LEN = 5000;   // Máximo de caracteres por documento (trunca o excedente)
 


### PR DESCRIPTION
## O que foi feito

Corrige hallucination do chatbot em modo RESERVA quando o anfitrião anexa um `.md` de políticas. Atua nas 3 causas raiz: chunking de Markdown, threshold de similaridade do RAG e ausência de guardrail quando não há documentos.
Linear: [RES-95](https://linear.app/reservaqui/issue/RES-95/fix-rag-hallucination-guardrail-obrigatorio-no-modo-reserva-fix)

## Arquivos modificados

- `Backend/src/services/ai/agentOrchestrator.service.ts`
  - RAG passa a ser guardrail obrigatório no modo RESERVA
  - Quando não há documentos indexados, injeta bloco restritivo proibindo a LLM de inventar comodidades/políticas
  - Em erro técnico do RAG, injeta um guardrail mínimo para evitar fallback livre da LLM
- `Backend/src/services/ai/rag.service.ts`
  - Threshold `RAG_MIN_RELEVANCE_SCORE` baixado de `0.70` → `0.55` para que chunks de política em prosa entrem no contexto
- `Backend/src/controllers/policyUpload.controller.ts`
  - `chunkText` agora normaliza Markdown antes de chunkar: insere `\n\n` antes de headers `#`, listas `-*` e listas numeradas `1.`

## Checklist de validação

- [ ] Após upload de `.md` de políticas, o chatbot só responde com base no conteúdo indexado
- [ ] Quando não há documentos indexados, o bot recusa inventar comodidades/políticas
- [ ] Chunks de Markdown são quebrados corretamente por headers e listas
- [ ] Score mínimo 0.55 traz chunks de política em prosa para o contexto