### PR TITLE
🐛(fix): blindar sendEmail e validar walkInEmail (RES-99)

### DIFF
--- a/Backend/src/services/ai/tools.ts
+++ b/Backend/src/services/ai/tools.ts
@@ -137,7 +137,7 @@ export const buildAgentTools = (context: ChatContext | null) => {
         dataCheckin: z.string().describe('Data de check-in (formato YYYY-MM-DD).'),
         dataCheckout: z.string().describe('Data de check-out (formato YYYY-MM-DD).'),
         walkInNome: z.string().optional().describe('Nome completo do hóspede. OBRIGATÓRIO se o usuário não estiver logado.'),
-        walkInEmail: z.string().optional().describe('Email do hóspede. OBRIGATÓRIO se o usuário não estiver logado. Será usado para enviar a confirmação e o link de pagamento.'),
+        walkInEmail: z.string().email('walkInEmail deve ser um endereço de email válido (ex.: nome@dominio.com).').optional().describe('Email do hóspede. OBRIGATÓRIO se o usuário não estiver logado. Será usado para enviar a confirmação e o link de pagamento. Deve ser um endereço válido (nome@dominio.com) — nunca passe a palavra "email" literalmente.'),
         walkInTelefone: z.string().optional().describe('Telefone ou WhatsApp do hóspede (apenas números). OBRIGATÓRIO se o usuário não estiver logado.'),
       }),
     }

--- a/Backend/src/services/email.service.ts
+++ b/Backend/src/services/email.service.ts
@@ -81,32 +81,44 @@ function resolveFromHeader(): string {
 
 // ── API Pública ───────────────────────────────────────────────────────────────
 
+/** Regex simples de email — mesma usada em Reserva.validateEmail e Usuario. */
+const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
 /**
  * Envia um email. Fire-and-forget seguro: erros são logados mas nunca propagam.
  * Chamadores devem usar .catch(() => {}) se quiserem ignorar a Promise.
  */
 export async function sendEmail(input: SendEmailInput): Promise<void> {
+  // Guard: rejeita destinatário inválido antes de qualquer trabalho.
+  // Sem isso, o Nodemailer estoura "No recipients defined" e polui o log
+  // — pior, esconde a causa raiz (dado ruim entrando no campo).
+  const to = typeof input.to === 'string' ? input.to.trim() : '';
+  if (!to || !EMAIL_RE.test(to)) {
+    console.warn(`[email] destinatário inválido (ignorado): to="${input.to}" subject="${input.subject}"`);
+    return;
+  }
+
   const transporter = getTransporter();
 
   if (!transporter) {
-    console.warn(`[email] (no-op) Para ${input.to}: ${input.subject}`);
+    console.warn(`[email] (no-op) Para ${to}: ${input.subject}`);
     return;
   }
 
   const from = resolveFromHeader();
 
-  console.log(`[email] enviando from="${from}" to=${input.to} assunto="${input.subject}"`);
+  console.log(`[email] enviando from="${from}" to=${to} assunto="${input.subject}"`);
   try {
     const info = await transporter.sendMail({
       from,
-      to:      input.to,
+      to,
       subject: input.subject,
       html:    input.html,
       text:    input.text ?? stripHtml(input.html),
     });
-    console.log(`[email] OK to=${input.to} messageId=${info.messageId} accepted=${JSON.stringify(info.accepted)} rejected=${JSON.stringify(info.rejected)} response="${info.response}"`);
+    console.log(`[email] OK to=${to} messageId=${info.messageId} accepted=${JSON.stringify(info.accepted)} rejected=${JSON.stringify(info.rejected)} response="${info.response}"`);
   } catch (err) {
-    console.warn(`[email] FALHA to=${input.to}:`, (err as Error).message);
+    console.warn(`[email] FALHA to=${to}:`, (err as Error).message);
     if ((err as Error).stack) console.warn((err as Error).stack);
   }
 }


### PR DESCRIPTION
## O que foi feito

Resolve [RES-99](https://linear.app/reservaqui/issue/RES-99/email-falha-com-destinatario-email-validar-entrada-e-blindar-sendemail) — emails de reserva não chegavam aos amigos no servidor remoto, embora chegassem ao dono do projeto.

Logs do servidor mostravam tentativas de envio com `to="email"` (a palavra literal):

```
[email] enviando from="ReservAqui <reserv.aqui.123@gmail.com>" to=email assunto="Reserva em Grand Paulista..."
[email] FALHA to=email: No recipients defined
```

Causa raiz: o LLM do bot, quando o usuário descrevia os dados em formato narrativo ("meu email é X, telefone é Y"), às vezes extraía o rótulo (`"email"`) em vez do valor. O schema do tool `criar_reserva` aceitava qualquer string, então o dado ruim chegava até o Nodemailer.

A correção aplica defesa em camadas, sem mudar o comportamento de envio para emails válidos.

## Arquivos modificados

- `Backend/src/services/email.service.ts`
  - Adicionada regex `EMAIL_RE` no nível do módulo.
  - `sendEmail` agora valida `input.to` antes de chamar `transporter.sendMail`. Se inválido, loga warn com o valor recebido + subject e retorna — sem poluir o log com "No recipients defined" do Nodemailer.
  - `to` agora é trimado e reaproveitado em todos os logs (antes usava `input.to` cru).
- `Backend/src/services/ai/tools.ts`
  - Schema do `walkInEmail` no tool `criar_reserva` mudou de `z.string().optional()` para `z.string().email(...).optional()`. Mensagem de erro custom orienta o agente.
  - Description do campo reforça que nunca se deve passar a palavra "email" como valor.

## Checklist de validação

- [x] `sendEmail({ to: 'email', ... })` não chama `transporter.sendMail` e loga warn com o valor inválido
- [x] `sendEmail({ to: 'foo@bar.com', ... })` continua funcionando normalmente
- [x] Schema do `criar_reserva` rejeita `walkInEmail: "email"` com mensagem de validação do Zod
- [x] `emailTemplates.test.ts` continua passando (23/23)
- [x] `tsc --noEmit` limpo
- [ ] Smoke test no servidor: criar reserva pelo bot passando email válido e verificar que o email chega
- [ ] Smoke test no servidor: tentar passar `email` literal e ver o warn no log sem o erro do Nodemailer

## Fora do escopo

Diagnóstico de registros já corrompidos em `public.usuario` / `reserva.email_hospede`. Será feito manualmente no servidor com query SQL e tratado em ticket separado se aparecer algo.