### PR TITLE
fix(frontend): corrige import de PrimaryButton e busca por nome de estado

### DIFF
--- a/Frontend/lib/features/auth/presentation/pages/login_page.dart
+++ b/Frontend/lib/features/auth/presentation/pages/login_page.dart
@@ -9,6 +9,7 @@ import '../../../../core/utils/breakpoints.dart';
 import '../../../../core/widgets/custom_app_bar.dart';
 import '../../data/services/auth_service.dart';
 import '../../data/models/auth_response.dart';
+import '../../../../core/widgets/primary_button.dart';
 import '../widgets/auth_text_field.dart';
 import '../widgets/login_form.dart';
 

--- a/Frontend/lib/features/search/presentation/providers/search_provider.dart
+++ b/Frontend/lib/features/search/presentation/providers/search_provider.dart
@@ -59,6 +59,54 @@ class SearchState {
   }
 }
 
+const _estadoParaUF = <String, String>{
+  'acre': 'AC',
+  'alagoas': 'AL',
+  'amapa': 'AP',
+  'amazonas': 'AM',
+  'bahia': 'BA',
+  'ceara': 'CE',
+  'distrito federal': 'DF',
+  'espirito santo': 'ES',
+  'goias': 'GO',
+  'maranhao': 'MA',
+  'mato grosso': 'MT',
+  'mato grosso do sul': 'MS',
+  'minas gerais': 'MG',
+  'para': 'PA',
+  'paraiba': 'PB',
+  'parana': 'PR',
+  'pernambuco': 'PE',
+  'piaui': 'PI',
+  'rio de janeiro': 'RJ',
+  'rio grande do norte': 'RN',
+  'rio grande do sul': 'RS',
+  'rondonia': 'RO',
+  'roraima': 'RR',
+  'santa catarina': 'SC',
+  'sao paulo': 'SP',
+  'sergipe': 'SE',
+  'tocantins': 'TO',
+};
+
+/// Normaliza removendo acentos e convertendo para minúsculo.
+String _normalize(String s) {
+  const accents = 'àáâãäåèéêëìíîïòóôõöùúûüýÿñçÀÁÂÃÄÅÈÉÊËÌÍÎÏÒÓÔÕÖÙÚÛÜÝŸÑÇ';
+  const plain   = 'aaaaaaeeeeiiiioooooouuuuyynnccAAAAAAEEEEIIIIOOOOOUUUUYYNNCC';
+  var result = s.toLowerCase();
+  for (var i = 0; i < accents.length; i++) {
+    result = result.replaceAll(accents[i], plain[i]);
+  }
+  return result.trim();
+}
+
+/// Se o termo digitado for um nome de estado completo, retorna a sigla UF.
+/// Caso contrário devolve o termo original.
+String _resolveSearchTerm(String q) {
+  final uf = _estadoParaUF[_normalize(q)];
+  return uf ?? q;
+}
+
 class SearchNotifier extends Notifier<SearchState> {
   late final SearchService _service;
 
@@ -78,7 +126,7 @@ class SearchNotifier extends Notifier<SearchState> {
       return;
     }
 
-    final q = state.destination.trim();
+    final q = _resolveSearchTerm(state.destination.trim());
 
     try {
       final results = await _service.searchRooms(q: q);
@@ -145,7 +193,7 @@ class SearchNotifier extends Notifier<SearchState> {
   }
 
   Future<void> performSearch() async {
-    final q = state.destination.trim();
+    final q = _resolveSearchTerm(state.destination.trim());
     final dateRange = state.dateRange;
 
     state = state.copyWith(isLoading: true, clearError: true);


### PR DESCRIPTION
## Summary

- Adicionado import faltante de `primary_button.dart` em `login_page.dart`, que impedia o build do app
- Adicionado mapeamento de nomes completos de estados brasileiros → sigla UF em `search_provider.dart`, permitindo que buscas como "Rio Grande do Sul" encontrem hotéis com `uf='RS'`

## Contexto

O `login_page.dart` usava o widget `PrimaryButton` no formulário mobile sem importá-lo, causando erro de compilação. O fix foi adicionar o import correto.

Na busca, o campo `uf` no banco armazena a sigla (ex: `RS`), então digitar o nome completo do estado não retornava resultados. O fix converte o nome do estado para a sigla antes de enviar a query à API.

> **Nota:** a busca por sigla curta (ex: `BA`) ainda pode gerar falsos positivos em nomes de hotéis/cidades. Uma melhoria futura no backend pode tratar UFs com match exato separado.

## Test plan

- [ ] Verificar que o app compila sem erros
- [ ] Testar login mobile (botões `PrimaryButton` visíveis)
- [ ] Buscar por "Rio Grande do Sul" e confirmar que hotéis com `uf='RS'` aparecem
- [ ] Buscar por nome de cidade normalmente e confirmar que continua funcionando

🤖 Generated with [Claude Code](https://claude.com/claude-code)