### PR TITLE
🐛(fix): mover validação de walkInEmail pro handler (RES-101 / hotfix RES-99)

### DIFF
--- a/Backend/src/services/ai/tools.ts
+++ b/Backend/src/services/ai/tools.ts
@@ -104,6 +104,15 @@ export const buildAgentTools = (context: ChatContext | null) => {
         return "ERRO DE VALIDAÇÃO: O usuário não está autenticado. Você DEVE obrigatoriamente perguntar o NOME COMPLETO, EMAIL e TELEFONE (WhatsApp) do usuário antes de chamar essa ferramenta novamente.";
       }
 
+      // Validação de formato do email em runtime — não no schema Zod, porque
+      // o JSON Schema gerado por z.string().email() usa uma regex com features
+      // que o Groq rejeita (invalid 'regex' format). Mantendo a checagem aqui
+      // dentro, garantimos que dado ruim (ex.: "email" literal) não entre no
+      // banco sem quebrar o registro da tool no provider.
+      if (walkInEmail && !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(walkInEmail)) {
+        return `ERRO DE VALIDAÇÃO: "${walkInEmail}" não é um email válido. Pergunte o endereço de email completo (formato nome@dominio.com) e chame a tool novamente com o valor correto.`;
+      }
+
       try {
         const reserva = await createReservaChat({
           hotel_id:       context.hotelId,
@@ -137,7 +146,7 @@ export const buildAgentTools = (context: ChatContext | null) => {
         dataCheckin: z.string().describe('Data de check-in (formato YYYY-MM-DD).'),
         dataCheckout: z.string().describe('Data de check-out (formato YYYY-MM-DD).'),
         walkInNome: z.string().optional().describe('Nome completo do hóspede. OBRIGATÓRIO se o usuário não estiver logado.'),
-        walkInEmail: z.string().email('walkInEmail deve ser um endereço de email válido (ex.: nome@dominio.com).').optional().describe('Email do hóspede. OBRIGATÓRIO se o usuário não estiver logado. Será usado para enviar a confirmação e o link de pagamento. Deve ser um endereço válido (nome@dominio.com) — nunca passe a palavra "email" literalmente.'),
+        walkInEmail: z.string().optional().describe('Email do hóspede. OBRIGATÓRIO se o usuário não estiver logado. Deve ser um endereço válido no formato nome@dominio.com — nunca passe a palavra "email" literalmente, sempre o endereço real informado pelo usuário. Será usado para enviar a confirmação e o link de pagamento.'),
         walkInTelefone: z.string().optional().describe('Telefone ou WhatsApp do hóspede (apenas números). OBRIGATÓRIO se o usuário não estiver logado.'),
       }),
     }


### PR DESCRIPTION
## O que foi feito

Resolve [RES-101](https://linear.app/reservaqui/issue/RES-101/hotfix-res-99-zstringemail-em-walkinemail-quebra-registro-da-tool-no) — hotfix urgente do PR #137 (RES-99).

O `z.string().email()` que adicionei no `walkInEmail` é traduzido pra um JSON Schema com regex que o Groq rejeita:

```
invalid JSON schema for tool criar_reserva,
tools[3].function.parameters: ... '/properties/walkInEmail/pattern'
... is not valid 'regex'
```

Resultado: o bot inteiro deixa de funcionar — sem registro da tool `criar_reserva`, nenhuma reserva é criada via chat e nenhum email é enviado.

## Arquivos modificados

- `Backend/src/services/ai/tools.ts`
  - Schema do `walkInEmail` volta a ser `z.string().optional()` (sem `.email()`).
  - Reforçado o `describe` orientando o agente a sempre passar endereço real.
  - Adicionada validação de formato **dentro do handler** com regex simples (`/^[^\s@]+@[^\s@]+\.[^\s@]+$/`). Se inválido, retorna ERRO DE VALIDAÇÃO orientando o LLM a refazer a pergunta.

## Por que essa abordagem

Qualquer pattern via Zod corre risco do mesmo problema (o Zod gera regex com features que vários validadores JSON Schema estritos não aceitam). Validar no handler:
- Não toca no JSON Schema → seguro com qualquer LLM provider
- Mantém a blindagem contra dado ruim entrando no banco
- Dá feedback claro pro modelo refazer a pergunta

## Checklist de validação

- [x] `tsc --noEmit` limpo
- [ ] Após deploy, `BadRequestError: 400 ... invalid JSON schema` some dos logs
- [ ] Reserva via bot volta a funcionar
- [ ] Bot rejeita `walkInEmail: "email"` com a mensagem de validação e refaz a pergunta