### PR TITLE
✨(feat): enviar email de pagamento pendente também pelo fluxo do app (RES-102)

### DIFF
--- a/Backend/src/controllers/pagamentoReserva.controller.ts
+++ b/Backend/src/controllers/pagamentoReserva.controller.ts
@@ -8,6 +8,7 @@ import {
   getPagamentoPublic,
   confirmarPagamentoFake,
   cancelarPagamentoFake,
+  sendPaymentPendingEmail,
 } from '../services/pagamentoReserva.service';
 import { PagamentoReserva, FormaPagamento } from '../entities/PagamentoReserva';
 
@@ -76,6 +77,16 @@ export async function createPagamentoPublicoController(
     const codigoPublico = req.params.codigo_publico;
     const canal = (req.body?.canal === 'WHATSAPP' ? 'WHATSAPP' : 'APP') as 'APP' | 'WHATSAPP';
     const result = await createPagamentoFake({ codigoPublico, canal });
+
+    // Dispara email pendente com o link de pagamento. O bot já fazia isso via
+    // sendPaymentLinkViaWhatsApp; agora o app também recebe a mesma mensagem.
+    // Fire-and-forget: erro no email não trava a resposta da reserva.
+    sendPaymentPendingEmail({
+      codigoPublico,
+      pagamentoId: result.pagamento_id,
+      expiresAt:   result.expires_at,
+    }).catch(() => {});
+
     res.status(201).json({ data: result });
   } catch (err) {
     const message = err instanceof Error ? err.message : 'Erro interno';

--- a/Backend/src/services/pagamentoReserva.service.ts
+++ b/Backend/src/services/pagamentoReserva.service.ts
@@ -7,7 +7,7 @@ import { setQuartoDisponivel } from './quarto.service';
 import { _ensureReservaFluxoColumns } from './reserva.service';
 import { sendApprovedReservationConfirmation } from './whatsappReservation.service';
 import { sendEmail } from './email.service';
-import { reservaConfirmadaTemplate } from './emailTemplates';
+import { reservaConfirmadaTemplate, reservaPendentePagamentoTemplate } from './emailTemplates';
 import {
   PagamentoReserva,
   PagamentoReservaSafe,
@@ -92,6 +92,74 @@ export async function cancelarPagamentoFake(
   pagamentoId:   number,
 ): Promise<PagamentoFakeResumo> {
   return _cancelarPagamentoFake(codigoPublico, pagamentoId);
+}
+
+/**
+ * Dispara o email "pagamento pendente" com o link de checkout.
+ * Compartilhado entre o fluxo do bot (WhatsApp/chat) e o do app — garante que
+ * o hóspede sempre receba o link após gerar o pagamento, independente do canal.
+ * Fire-and-forget: erros são apenas logados, nunca propagam.
+ */
+export async function sendPaymentPendingEmail(input: {
+  codigoPublico: string;
+  pagamentoId:   number;
+  expiresAt?:    string | null;
+}): Promise<void> {
+  try {
+    const { schema_name, nome_hotel } = await _resolveTenantByCodigoPublico(input.codigoPublico);
+
+    const row = await withTenant(schema_name, async (client) => {
+      await _ensureReservaFluxoColumns(client);
+      const { rows } = await client.query<{
+        email_hospede: string | null;
+        user_email:    string | null;
+        nome_hospede:  string | null;
+        user_nome:     string | null;
+        tipo_quarto:   string | null;
+        data_checkin:  string;
+        data_checkout: string;
+        num_hospedes:  number;
+        valor_total:   string;
+      }>(
+        `SELECT r.email_hospede, u.email AS user_email,
+                r.nome_hospede, u.nome_completo AS user_nome,
+                r.tipo_quarto, r.data_checkin, r.data_checkout,
+                r.num_hospedes, r.valor_total
+         FROM reserva r
+         LEFT JOIN public.usuario u ON u.user_id = r.user_id
+         WHERE r.codigo_publico = $1`,
+        [input.codigoPublico],
+      );
+      return rows[0] ?? null;
+    });
+
+    if (!row) return;
+
+    const destinoEmail = row.email_hospede ?? row.user_email ?? null;
+    if (!destinoEmail) return;
+
+    const frontend     = (process.env.FRONTEND_URL ?? 'http://localhost:8080').replace(/\/+$/, '');
+    const pagamentoUrl = `${frontend}/pagamento/${input.codigoPublico}/${input.pagamentoId}`;
+
+    const { subject, html } = reservaPendentePagamentoTemplate({
+      nomeHospede:   row.nome_hospede ?? row.user_nome ?? 'Hóspede',
+      codigoPublico: input.codigoPublico,
+      pagamentoUrl,
+      expiresAt:     input.expiresAt ?? null,
+      resumo: {
+        nomeHotel:    nome_hotel,
+        tipoQuarto:   row.tipo_quarto ?? 'Quarto',
+        dataCheckin:  row.data_checkin,
+        dataCheckout: row.data_checkout,
+        numHospedes:  row.num_hospedes,
+        valorTotal:   row.valor_total,
+      },
+    });
+
+    sendEmail({ to: destinoEmail, subject, html }).catch(() => {});
+  } catch (err) {
+    console.warn('[pagamento] sendPaymentPendingEmail falhou:', (err as Error).message);
+  }
 }
 
 // ── Helpers Privados ──────────────────────────────────────────────────────────

--- a/Backend/src/services/whatsappReservation.service.ts
+++ b/Backend/src/services/whatsappReservation.service.ts
@@ -265,9 +265,7 @@ export async function sendPaymentLinkViaWhatsApp(input: {
   reservaId: number;
 }): Promise<void> {
   // Import dinâmico para evitar ciclo com pagamentoReserva.service
-  const { createPagamentoFake } = await import('./pagamentoReserva.service');
-  const { sendEmail }           = await import('./email.service');
-  const { reservaPendentePagamentoTemplate } = await import('./emailTemplates');
+  const { createPagamentoFake, sendPaymentPendingEmail } = await import('./pagamentoReserva.service');
 
   try {
     const reservation = await getReservationForConfirmation(input.hotelId, input.reservaId);
@@ -318,48 +316,15 @@ export async function sendPaymentLinkViaWhatsApp(input: {
       }
     }
 
-    // Email — usa email_hospede quando presente, cai no user se autenticado
-    const reservaRow = await getReservationEmailRow(input.hotelId, input.reservaId);
-    const destinoEmail = reservaRow?.email_hospede ?? reservaRow?.user_email ?? null;
-    const nomeDestino  = reservation.nome_hospede ?? userContact?.nome_completo ?? 'Hóspede';
-
-    if (destinoEmail) {
-      const { subject, html } = reservaPendentePagamentoTemplate({
-        nomeHospede:   nomeDestino,
-        codigoPublico: reservation.codigo_publico,
-        pagamentoUrl,
-        expiresAt:     pagamento.expires_at,
-        resumo: {
-          nomeHotel:    reservation.nome_hotel,
-          tipoQuarto:   reservation.tipo_quarto ?? 'Quarto',
-          dataCheckin:  reservation.data_checkin,
-          dataCheckout: reservation.data_checkout,
-          numHospedes:  1, // `ReservationRow` não tem num_hospedes; fallback neutro
-          valorTotal:   reservation.valor_total,
-        },
-      });
-      sendEmail({ to: destinoEmail, subject, html }).catch(() => {});
-    }
+    // Email — helper compartilhado com o fluxo do app. Resolve destinatário
+    // (email_hospede ou user_email) e dispara o template "pagamento pendente".
+    await sendPaymentPendingEmail({
+      codigoPublico: reservation.codigo_publico,
+      pagamentoId:   pagamento.pagamento_id,
+      expiresAt:     pagamento.expires_at,
+    });
   } catch (err) {
     console.warn('[wppReservation] sendPaymentLinkViaWhatsApp falhou:', err);
   }
 }
 
-async function getReservationEmailRow(
-  hotelId:   string,
-  reservaId: number,
-): Promise<{ email_hospede: string | null; user_email: string | null } | null> {
-  const hotel = await getHotelInfo(hotelId);
-  const { _ensureReservaFluxoColumns } = await import('./reserva.service');
-  return withTenant(hotel.schema_name, async (client) => {
-    await _ensureReservaFluxoColumns(client);
-    const { rows } = await client.query<{ email_hospede: string | null; user_email: string | null }>(
-      `SELECT r.email_hospede, u.email AS user_email
-       FROM reserva r
-       LEFT JOIN public.usuario u ON u.user_id = r.user_id
-       WHERE r.id = $1`,
-      [reservaId],
-    );
-    return rows[0] ?? null;
-  });
-}


### PR DESCRIPTION
## O que foi feito

Resolve [RES-102](https://linear.app/reservaqui/issue/RES-102/paridade-de-email-enviar-email-pendente-quando-reserva-e-criada-pelo). O bot/WhatsApp já enviava o email \"Reserva em X — pagamento pendente\" logo após criar a reserva, com o link de pagamento. Pelo app, esse email não saía — quem reservava ficava sem registro do link caso fechasse a aba.

## Mudança principal

Lógica de envio de email pendente extraída do helper do WhatsApp para um helper exportado em `pagamentoReserva.service.ts`. Bot e app agora consomem o mesmo helper. Resultado: paridade completa — o email chega no mesmo formato, independente do canal de origem.

## Arquivos modificados

- `Backend/src/services/pagamentoReserva.service.ts`
  - Novo `sendPaymentPendingEmail({ codigoPublico, pagamentoId, expiresAt? })`: resolve destinatário (`email_hospede` ou `user_email` via JOIN com `public.usuario`), monta URL `${FRONTEND_URL}/pagamento/{codigo}/{id}`, dispara `reservaPendentePagamentoTemplate`.
  - Fire-and-forget: erros só logados (`[pagamento] sendPaymentPendingEmail falhou`).
  - Import de `reservaPendentePagamentoTemplate` adicionado no topo.
- `Backend/src/controllers/pagamentoReserva.controller.ts`
  - `createPagamentoPublicoController` agora chama `sendPaymentPendingEmail` após criar o pagamento. Não bloqueia a resposta — \`.catch(() => {})\`.
- `Backend/src/services/whatsappReservation.service.ts`
  - `sendPaymentLinkViaWhatsApp` agora usa `sendPaymentPendingEmail` em vez da lógica inline.
  - Função local `getReservationEmailRow` removida (sem mais consumidores).
  - Comportamento idêntico ao anterior — testado via `emailTemplates.test.ts` (23/23 passam).

## Decisão de design

`expires_at` continua sendo setado só pelo fluxo do bot (+30min). No app, o pagamento é criado com `expires_at = null` — o template já trata o campo como opcional (não exibe o aviso de \"expira em 30 minutos\"). Se for desejado uniformizar, abrir card separado.

## Checklist de validação

- [x] `tsc --noEmit` limpo
- [x] `emailTemplates.test.ts` passa (23/23)
- [ ] Após deploy, criar reserva pelo app → log mostra `[email] enviando ... assunto=\"Reserva em X — pagamento pendente\"`
- [ ] Email chega no destinatário com link `/pagamento/{codigo}/{id}` funcional
- [ ] Bot continua enviando email igual (regressão zero)