### PR TITLE
🐛(fix): preencher hóspede da reserva com perfil do usuário (RES-103)

### DIFF
--- a/Backend/src/services/reserva.service.ts
+++ b/Backend/src/services/reserva.service.ts
@@ -327,6 +327,34 @@ async function _createReservaUsuario(
   Reserva.validateUsuario(input);
   const { schema_name, nome_hotel } = await _getHotelInfo(input.hotel_id);
 
+  // Reserva no próprio nome (sem dados de hóspede) → preenche com o perfil do
+  // usuário pra reserva não chegar como "Hóspede" nas telas do hotel (RES-103).
+  let nomeHospede     = input.nome_hospede     ?? null;
+  let cpfHospede      = input.cpf_hospede      ?? null;
+  let emailHospede    = input.email_hospede    ?? null;
+  let telefoneContato = input.telefone_contato ?? null;
+
+  if (!nomeHospede) {
+    const { rows: userRows } = await masterPool.query<{
+      nome_completo:  string | null;
+      email:          string | null;
+      cpf:            string | null;
+      numero_celular: string | null;
+    }>(
+      `SELECT nome_completo, email, cpf, numero_celular
+         FROM usuario
+        WHERE user_id = $1 AND ativo = TRUE`,
+      [userId],
+    );
+    const u = userRows[0];
+    if (u) {
+      nomeHospede     = u.nome_completo;
+      emailHospede    = u.email;
+      cpfHospede      = u.cpf;
+      telefoneContato = u.numero_celular;
+    }
+  }
+
   return withTenant(schema_name, async (client) => {
     await _ensureReservaFluxoColumns(client);
     // Garante hospede registrado no tenant
@@ -363,10 +391,10 @@ async function _createReservaUsuario(
        RETURNING *`,
       [
         userId,
-        input.nome_hospede     ?? null,
-        input.cpf_hospede      ?? null,
-        input.telefone_contato ?? null,
-        input.email_hospede    ?? null,
+        nomeHospede,
+        cpfHospede,
+        telefoneContato,
+        emailHospede,
         input.quarto_id    ?? null,
         input.tipo_quarto  ?? null,
         input.num_hospedes,


### PR DESCRIPTION
## O que foi feito

Reservas criadas pelo app Flutter com usuário logado estavam salvando `nome_hospede = NULL`, fazendo as telas do hotel exibirem "Hóspede" (ou o `user_id` cru) em vez do nome do usuário. Quando o front não envia dados de hóspede (caminho dominante — usuário só confirma o form pré-preenchido), o backend agora busca `nome_completo`, `email`, `cpf` e `numero_celular` da tabela `usuario` e grava na reserva. Como o pré-preenchimento do front vem da mesma tabela, o valor gravado é idêntico ao que o usuário viu na tela.

Issue: [RES-103](https://linear.app/reservaqui/issue/RES-103)

## Arquivos modificados

- `Backend/src/services/reserva.service.ts`
  - `_createReservaUsuario`: antes do `withTenant`, se `input.nome_hospede` for null, consulta o perfil em `usuario` via `masterPool` e usa esses valores no INSERT. Caminho de "reserva para terceiro" (form editado) continua igual.

## Por que essa abordagem

- 1 função alterada, nenhum caller mudou.
- Não toca dashboard, agendamentos, emails, frontend nem os fluxos walk-in/guest.
- Reservas existentes seguem inalteradas (sem regressão visual).
- Alternativa "frontend sempre envia" foi descartada porque faria toda reserva autenticada parecer "reserva para terceiro" no backend, distorcendo a semântica do campo.

## Checklist de validação

- [ ] Reserva nova criada pelo app logado (sem editar o form) → `nome_hospede` no banco = `usuario.nome_completo`
- [ ] Reserva nova criada pelo app logado editando o form → grava os dados editados (comportamento atual mantido)
- [ ] Reserva walk-in feita pelo hotel → continua aceitando `nome_hospede` opcional (sem regressão)
- [ ] Reserva guest (sem login) → continua exigindo dados completos (sem regressão)
- [ ] Tela de agendamentos do hotel exibe o nome do usuário em reservas novas