### PR TITLE
fix: corrigir verificação de disponibilidade — contar quartos livres em vez de subtrair ocupados

### DIFF
--- a/Backend/src/services/categoriaQuarto.service.ts
+++ b/Backend/src/services/categoriaQuarto.service.ts
@@ -341,11 +341,11 @@ async function _verificarDisponibilidade(
          cq.preco_base::TEXT           AS valor_diaria,
          cq.capacidade_pessoas,
          COALESCE(total.cnt,  0)::INT  AS total_quartos,
-         GREATEST(0, COALESCE(total.cnt, 0) - COALESCE(ocupados.cnt, 0))::INT AS quartos_disponiveis,
-         (GREATEST(0, COALESCE(total.cnt, 0) - COALESCE(ocupados.cnt, 0)) > 0) AS disponivel,
+         COALESCE(livres.cnt, 0)::INT  AS quartos_disponiveis,
+         (COALESCE(livres.cnt, 0) > 0) AS disponivel,
          CASE
            WHEN COALESCE(total.cnt, 0) > 0
-            AND COALESCE(total.cnt, 0) <= COALESCE(ocupados.cnt, 0)
+            AND COALESCE(livres.cnt, 0) = 0
            THEN (
              SELECT MIN(r2.data_checkout)::TEXT
              FROM reserva r2
@@ -367,16 +367,20 @@ async function _verificarDisponibilidade(
          GROUP BY categoria_quarto_id
        ) total ON total.categoria_quarto_id = cq.id
 
-       -- quartos com reservas ativas sobrepostas ao período
+       -- quartos sem reserva conflitante no período (mesma lógica do INSERT-time check)
        LEFT JOIN (
-         SELECT q.categoria_quarto_id, COUNT(DISTINCT q.id) AS cnt
-         FROM reserva r
-         JOIN quarto  q ON q.id = r.quarto_id
-         WHERE r.status       NOT IN ('CANCELADA')
-           AND r.data_checkin  < $2
-           AND r.data_checkout > $1
+         SELECT q.categoria_quarto_id, COUNT(*) AS cnt
+         FROM quarto q
+         WHERE q.deleted_at IS NULL
+           AND NOT EXISTS (
+             SELECT 1 FROM reserva r
+             WHERE r.quarto_id    = q.id
+               AND r.status       NOT IN ('CANCELADA')
+               AND r.data_checkin  < $2
+               AND r.data_checkout > $1
+           )
          GROUP BY q.categoria_quarto_id
-       ) ocupados ON ocupados.categoria_quarto_id = cq.id
+       ) livres ON livres.categoria_quarto_id = cq.id
 
        WHERE cq.deleted_at IS NULL
        ORDER BY cq.nome`,


### PR DESCRIPTION
## Problema

O endpoint `GET /hotel/:hotel_id/disponibilidade` sempre retornava disponível mesmo quando todos os quartos da categoria estavam reservados.

### Causa raiz

A função `_verificarDisponibilidade` em `categoriaQuarto.service.ts` calculava disponibilidade com aritmética sobre um sub-join defeituoso:

```sql
GREATEST(0, total - ocupados) AS quartos_disponiveis
```

O sub-join `ocupados` era construído assim:

```sql
SELECT q.categoria_quarto_id, COUNT(DISTINCT q.id) AS cnt
FROM reserva r
JOIN quarto q ON q.id = r.quarto_id   -- descarta reservas walk-in (quarto_id = NULL)
WHERE r.status NOT IN ('CANCELADA')
  AND r.data_checkin  < $2
  AND r.data_checkout > $1
GROUP BY q.categoria_quarto_id
```

**Problemas identificados:**
1. O `JOIN quarto q ON q.id = r.quarto_id` ignora reservas onde `quarto_id IS NULL` (walk-ins), subestimando `ocupados` e fazendo o sistema reportar disponibilidade falsa.
2. A abordagem de subtração aritmética é inerentemente frágil: qualquer inconsistência de contagem resulta em disponibilidade falsa.

---

## Solução

Substituição total do sub-join `ocupados` pelo sub-join `livres`, que usa `NOT EXISTS` — exatamente a mesma lógica já aplicada no INSERT-time check de `_createReservaUsuario`.

### Arquivo modificado

**`Backend/src/services/categoriaQuarto.service.ts`** — função `_verificarDisponibilidade`

---

## Mudanças detalhadas

### 1. Sub-join `ocupados` → `livres`

**Antes:**
```sql
LEFT JOIN (
  SELECT q.categoria_quarto_id, COUNT(DISTINCT q.id) AS cnt
  FROM reserva r
  JOIN quarto q ON q.id = r.quarto_id
  WHERE r.status NOT IN ('CANCELADA')
    AND r.data_checkin  < $2
    AND r.data_checkout > $1
  GROUP BY q.categoria_quarto_id
) ocupados ON ocupados.categoria_quarto_id = cq.id
```

**Depois:**
```sql
LEFT JOIN (
  SELECT q.categoria_quarto_id, COUNT(*) AS cnt
  FROM quarto q
  WHERE q.deleted_at IS NULL
    AND NOT EXISTS (
      SELECT 1 FROM reserva r
      WHERE r.quarto_id    = q.id
        AND r.status       NOT IN ('CANCELADA')
        AND r.data_checkin  < $2
        AND r.data_checkout > $1
    )
  GROUP BY q.categoria_quarto_id
) livres ON livres.categoria_quarto_id = cq.id
```

### 2. Cálculo de `quartos_disponiveis`

**Antes:**
```sql
GREATEST(0, COALESCE(total.cnt, 0) - COALESCE(ocupados.cnt, 0))::INT AS quartos_disponiveis
```

**Depois:**
```sql
COALESCE(livres.cnt, 0)::INT AS quartos_disponiveis
```

### 3. Flag `disponivel`

**Antes:**
```sql
(GREATEST(0, COALESCE(total.cnt, 0) - COALESCE(ocupados.cnt, 0)) > 0) AS disponivel
```

**Depois:**
```sql
(COALESCE(livres.cnt, 0) > 0) AS disponivel
```

### 4. Condição do `CASE` para `proxima_disponibilidade`

**Antes:**
```sql
WHEN COALESCE(total.cnt, 0) > 0
 AND COALESCE(total.cnt, 0) <= COALESCE(ocupados.cnt, 0)
```

**Depois:**
```sql
WHEN COALESCE(total.cnt, 0) > 0
 AND COALESCE(livres.cnt, 0) = 0
```

---

## O que não muda

- URLs, parâmetros e contrato de resposta do endpoint — inalterados.
- Frontend (tela de detalhes e tela de checkout) — nenhuma alteração necessária.
- Nenhum outro serviço ou controller é afetado.

---

## Como verificar

1. Reservar um quarto via app para datas futuras.
2. Na tela de detalhes da mesma categoria, selecionar aquele período → deve exibir **Indisponível**.
3. Selecionar período diferente → deve exibir **Disponível**.
4. Cancelar a reserva → disponibilidade volta ao normal.