### PR TITLE
planb: remover verificação de disponibilidade da tela de detalhes do quarto

### DIFF
--- a/Frontend/lib/features/rooms/presentation/pages/room_details_page.dart
+++ b/Frontend/lib/features/rooms/presentation/pages/room_details_page.dart
@@ -8,7 +8,6 @@ import '../../../../core/utils/breakpoints.dart';
 import '../../../../core/widgets/smart_network_image.dart';
 import '../../domain/models/room.dart';
 import '../notifiers/room_details_notifier.dart';
-import '../widgets/availability_checker.dart';
 import '../../../favorites/presentation/providers/favorites_provider.dart';
 import '../../../favorites/presentation/widgets/favorite_dialogs.dart';
 
@@ -29,10 +28,6 @@ class RoomDetailsPage extends ConsumerStatefulWidget {
 class _RoomDetailsPageState extends ConsumerState<RoomDetailsPage> {
   late PageController _photoController;
   int _currentPhotoIndex = 0;
-
-  // Datas escolhidas no AvailabilityChecker — propagadas ao checkout via queryParam
-  DateTime? _checkInDate;
-  DateTime? _checkOutDate;
 
   @override
   void initState() {
@@ -101,10 +96,8 @@ class _RoomDetailsPageState extends ConsumerState<RoomDetailsPage> {
                   ),
                 )
               : isDesktop
-                  ? _buildDesktopLayout(
-                      context, roomState.room!, isFavorite, roomState.categoriaId)
-                  : _buildMobileLayout(
-                      context, roomState.room!, isFavorite, roomState.categoriaId),
+                  ? _buildDesktopLayout(context, roomState.room!, isFavorite)
+                  : _buildMobileLayout(context, roomState.room!, isFavorite),
     );
   }
 
@@ -113,7 +106,7 @@ class _RoomDetailsPageState extends ConsumerState<RoomDetailsPage> {
   // ──────────────────────────────────────────────────────────────────────────
 
   Widget _buildDesktopLayout(
-      BuildContext context, Room room, bool isFavorite, int categoriaId) {
+      BuildContext context, Room room, bool isFavorite) {
     final colorScheme = Theme.of(context).colorScheme;
     final galleryUrls = room.imageUrls.isNotEmpty
         ? room.imageUrls
@@ -271,17 +264,6 @@ class _RoomDetailsPageState extends ConsumerState<RoomDetailsPage> {
                       _sectionTitle('Comodidades'),
                       const SizedBox(height: 12),
                       _buildAmenitiesGrid(room.amenities),
-                      if (categoriaId > 0) ...[
-                        const SizedBox(height: 24),
-                        AvailabilityChecker(
-                          hotelId: widget.hotelId,
-                          categoriaId: categoriaId,
-                          onDatesChanged: (ci, co) => setState(() {
-                            _checkInDate = ci;
-                            _checkOutDate = co;
-                          }),
-                        ),
-                      ],
                       const SizedBox(height: 28),
                       _sectionTitle('Detalhes'),
                       const SizedBox(height: 12),
@@ -351,15 +333,8 @@ class _RoomDetailsPageState extends ConsumerState<RoomDetailsPage> {
 
   void _goToCheckout(Room room) {
     final roomState = ref.read(roomDetailsNotifierProvider);
-    final base =
-        '/booking/checkout/${widget.hotelId}/${roomState.categoriaId}/${room.id}';
-    String url = base;
-    if (_checkInDate != null && _checkOutDate != null) {
-      final ci = _fmtDateIso(_checkInDate!);
-      final co = _fmtDateIso(_checkOutDate!);
-      url = '$base?checkin=$ci&checkout=$co';
-    }
-    context.push(url);
+    context.push(
+        '/booking/checkout/${widget.hotelId}/${roomState.categoriaId}/${room.id}');
   }
 
   Widget _sectionTitle(String text) {
@@ -379,7 +354,7 @@ class _RoomDetailsPageState extends ConsumerState<RoomDetailsPage> {
   // ──────────────────────────────────────────────────────────────────────────
 
   Widget _buildMobileLayout(
-      BuildContext context, Room room, bool isFavorite, int categoriaId) {
+      BuildContext context, Room room, bool isFavorite) {
     final colorScheme = Theme.of(context).colorScheme;
     return Stack(
       children: [
@@ -432,15 +407,6 @@ class _RoomDetailsPageState extends ConsumerState<RoomDetailsPage> {
                       ),
                       const SizedBox(height: 12),
                       _buildAmenitiesGrid(room.amenities),
-                      if (categoriaId > 0)
-                        AvailabilityChecker(
-                          hotelId: widget.hotelId,
-                          categoriaId: categoriaId,
-                          onDatesChanged: (ci, co) => setState(() {
-                            _checkInDate = ci;
-                            _checkOutDate = co;
-                          }),
-                        ),
                       const SizedBox(height: 32),
                       Text(
                         'Detalhes',
@@ -849,17 +815,7 @@ class _RoomDetailsPageState extends ConsumerState<RoomDetailsPage> {
             const SizedBox(width: 16),
             Expanded(
               child: ElevatedButton(
-                onPressed: () {
-                  final roomState = ref.read(roomDetailsNotifierProvider);
-                  final base = '/booking/checkout/${widget.hotelId}/${roomState.categoriaId}/${room.id}';
-                  String url = base;
-                  if (_checkInDate != null && _checkOutDate != null) {
-                    final ci = _fmtDateIso(_checkInDate!);
-                    final co = _fmtDateIso(_checkOutDate!);
-                    url = '$base?checkin=$ci&checkout=$co';
-                  }
-                  context.push(url);
-                },
+                onPressed: () => _goToCheckout(room),
                 style: ElevatedButton.styleFrom(
                   backgroundColor: AppColors.secondary,
                   foregroundColor: Colors.white,
@@ -881,6 +837,4 @@ class _RoomDetailsPageState extends ConsumerState<RoomDetailsPage> {
     );
   }
 
-  String _fmtDateIso(DateTime d) =>
-      '${d.year}-${d.month.toString().padLeft(2, '0')}-${d.day.toString().padLeft(2, '0')}';
 }


### PR DESCRIPTION
## Contexto

Este é o **Plano B** para o bug de disponibilidade sempre retornada como disponível (`GET /hotel/:hotel_id/disponibilidade`).

O Plano A (#147) corrige a query SQL no backend. Esta PR oferece uma alternativa de menor risco: retirar completamente o bloco de verificação de disponibilidade da tela de detalhes do quarto no frontend, sem tocar em nenhum código de backend.

> Usar esta PR **em vez da** #147, não junto.

---

## Problema

O widget `AvailabilityChecker` exibido na tela de detalhes do quarto consumia o endpoint `GET /hotel/:hotel_id/disponibilidade` que, por um bug no backend, sempre retornava `disponivel: true`. Isso induzia o usuário ao erro ao sugerir disponibilidade para períodos já totalmente ocupados.

---

## Solução

Remoção do `AvailabilityChecker` da tela de detalhes. O usuário segue direto para o checkout ao clicar em **Reservar**, onde a verificação real de conflito ocorre no momento do INSERT da reserva (lógica já correta no backend).

---

## Arquivo modificado

**`Frontend/lib/features/rooms/presentation/pages/room_details_page.dart`**

---

## Mudanças detalhadas

### 1. Import removido

```dart
// removido:
import '../widgets/availability_checker.dart';
```

### 2. State variables removidas

```dart
// removido:
DateTime? _checkInDate;
DateTime? _checkOutDate;
```

Estas variáveis só eram populadas via `onDatesChanged` do `AvailabilityChecker`. Sem o widget, nunca receberiam valor.

### 3. `AvailabilityChecker` removido do layout desktop

```dart
// removido do _buildDesktopLayout:
if (categoriaId > 0) ...[
  const SizedBox(height: 24),
  AvailabilityChecker(
    hotelId: widget.hotelId,
    categoriaId: categoriaId,
    onDatesChanged: (ci, co) => setState(() {
      _checkInDate = ci;
      _checkOutDate = co;
    }),
  ),
],
```

### 4. `AvailabilityChecker` removido do layout mobile

```dart
// removido do _buildMobileLayout:
if (categoriaId > 0)
  AvailabilityChecker(
    hotelId: widget.hotelId,
    categoriaId: categoriaId,
    onDatesChanged: (ci, co) => setState(() {
      _checkInDate = ci;
      _checkOutDate = co;
    }),
  ),
```

### 5. Parâmetro `categoriaId` removido das assinaturas dos layouts

```dart
// antes:
Widget _buildDesktopLayout(BuildContext context, Room room, bool isFavorite, int categoriaId)
Widget _buildMobileLayout(BuildContext context, Room room, bool isFavorite, int categoriaId)

// depois:
Widget _buildDesktopLayout(BuildContext context, Room room, bool isFavorite)
Widget _buildMobileLayout(BuildContext context, Room room, bool isFavorite)
```

### 6. `_goToCheckout` simplificado

```dart
// antes:
void _goToCheckout(Room room) {
  final base = '/booking/checkout/${widget.hotelId}/${roomState.categoriaId}/${room.id}';
  String url = base;
  if (_checkInDate != null && _checkOutDate != null) {
    final ci = _fmtDateIso(_checkInDate!);
    final co = _fmtDateIso(_checkOutDate!);
    url = '$base?checkin=$ci&checkout=$co';
  }
  context.push(url);
}

// depois:
void _goToCheckout(Room room) {
  context.push('/booking/checkout/${widget.hotelId}/${roomState.categoriaId}/${room.id}');
}
```

### 7. Botão "Reservar" mobile simplificado

O `onPressed` inline do bottom bar foi substituído por uma chamada ao `_goToCheckout(room)` já existente, eliminando duplicação de lógica.

### 8. Helper `_fmtDateIso` removido

```dart
// removido (usado apenas para formatar as datas do checker):
String _fmtDateIso(DateTime d) =>
    '${d.year}-${d.month.toString().padLeft(2, '0')}-${d.day.toString().padLeft(2, '0')}';
```

---

## O que não muda

- O widget `AvailabilityChecker` em si não é apagado — apenas não é mais usado nesta tela. Pode ser reaproveitado futuramente.
- O checkout (`/booking/checkout/...`) não é afetado.
- Nenhum outro serviço, controller ou tela é alterado.

---

## Trade-off

| | Plano A (#147) | Plano B (esta PR) |
|---|---|---|
| Corrige o dado errado? | Sim | Não exibe o dado |
| Risco de regressão | Médio (query SQL modificada) | Baixo (só frontend) |
| Usuário vê disponibilidade na tela de detalhes? | Sim, corretamente | Não vê |
| Datas pré-preenchidas no checkout? | Sim | Não |