### PR TITLE
🐛(fix): enviar tipo_quarto no payload de criação de reserva pelo app (RES-104)

### DIFF
--- a/Frontend/lib/features/booking/data/services/booking_service.dart
+++ b/Frontend/lib/features/booking/data/services/booking_service.dart
@@ -118,6 +118,7 @@ class BookingService {
       final data = <String, dynamic>{
         'hotel_id':     hotelId,
         'quarto_id':    quartoId,
+        'tipo_quarto':  tipoQuarto,
         'num_hospedes': numHospedes,
         'data_checkin': dataCheckin,
         'data_checkout': dataCheckout,


### PR DESCRIPTION
## O que foi feito

Reservas criadas pelo app Flutter com usuário logado estavam salvando `reserva.tipo_quarto = NULL` no banco — a tela de detalhes do ticket lê direto essa coluna (`ticket_details_page.dart:45`) e renderizava em branco. O método `createReserva` no `booking_service.dart` já recebia `tipoQuarto` como parâmetro mas não incluía no payload do POST. Agora inclui, igualando o `createReservaGuest` que já fazia certo (linha 170).

Issue: [RES-104](https://linear.app/reservaqui/issue/RES-104)

## Arquivos modificados

- `Frontend/lib/features/booking/data/services/booking_service.dart`
  - `createReserva`: adiciona `'tipo_quarto': tipoQuarto` ao map `data`. O parâmetro já existia na assinatura.

## Por que era só o app autenticado

- Guest (`createReservaGuest`): já enviava `tipo_quarto` no payload.
- Walk-in (`_createReservaWalkin`): hotel preenche o campo no form.
- Chat/WhatsApp: o input vem com `tipo_quarto` do agente IA.
- App autenticado: aceitava o parâmetro mas descartava na serialização — único caminho que perdia o dado.

## Auditoria dos demais campos

Comparei o contrato de `Reserva.validateUsuario` com o payload de `createReserva`. Único campo "tinha o dado mas não enviava" era o `tipo_quarto`. `observacoes` e `p_turisticos` também não são enviados, mas é porque o checkout do app não os coleta (não é regressão) — registrado como melhoria em [RES-105](https://linear.app/reservaqui/issue/RES-105) pra avaliação futura.

## Checklist de validação

- [ ] Reserva nova criada pelo app logado → coluna `reserva.tipo_quarto` no banco preenchida com o nome da categoria
- [ ] Tela de detalhes do ticket exibe o nome do quarto/categoria em reservas novas
- [ ] Reservas guest/walk-in/chat continuam exibindo o nome (sem regressão)