### PR TITLE
🐛(fix): resolver tipo_quarto via JOIN no detalhe do ticket quando NULL (RES-107)

### DIFF
--- a/Backend/src/services/reserva.service.ts
+++ b/Backend/src/services/reserva.service.ts
@@ -771,7 +771,15 @@ async function _getReservaByCodigoPublico(codigoPublico: string): Promise<Reserv
       [codigoPublico],
     );
     if (!rows[0]) throw new Error('Reserva não encontrada');
-    return rows[0];
+    const reserva = rows[0];
+
+    // Reservas criadas pelo chat/IA e algumas antigas chegam com tipo_quarto NULL.
+    // Resolve via JOIN com categoria_quarto pra UI não mostrar "—" (RES-107).
+    if (!reserva.tipo_quarto && reserva.quarto_id) {
+      reserva.tipo_quarto = await _resolveTipoQuarto(client, reserva.quarto_id, null);
+    }
+
+    return reserva;
   });
 }
 


### PR DESCRIPTION
## O que foi feito

A tela de detalhes do ticket no app continuava mostrando `—` no campo de quarto/categoria pra algumas reservas mesmo após o [RES-104](https://linear.app/reservaqui/issue/RES-104). Causa: o GET do detalhe (`_getReservaByCodigoPublico`) faz `SELECT * FROM reserva` direto, sem JOIN — então qualquer reserva com `reserva.tipo_quarto = NULL` (reservas antigas criadas antes do fix, ou criadas pelo chat/IA) vinha com NULL e a UI renderizava o fallback.

A lista (cards) não tem o problema porque lê de `historico_reserva_global.tipo_quarto`, que já é populado via `_resolveTipoQuarto` (JOIN com `categoria_quarto`) na gravação.

Fix puro de leitura: quando o `SELECT` retorna `tipo_quarto` null, resolve via `_resolveTipoQuarto` (função que já existe e faz o JOIN). Sem `UPDATE` no banco, sem mexer em INSERT, sem migration. É só a UI passar a receber o valor correto.

Issue: [RES-107](https://linear.app/reservaqui/issue/RES-107)

## Arquivos modificados

- `Backend/src/services/reserva.service.ts`
  - `_getReservaByCodigoPublico`: depois do SELECT, se `tipo_quarto` for null e `quarto_id` existir, chama `_resolveTipoQuarto`. 9 linhas adicionadas.

## Por que essa abordagem

- **Não toca lógica de criação** — nenhum INSERT, nenhuma validação, nenhum fluxo de criação muda.
- **Não migra dados** — banco fica intacto, sem UPDATE.
- **Reusa função existente** (`_resolveTipoQuarto`) — mesma lógica que o histórico global já usa há tempos.
- **Cobre todos os casos**: reservas antigas pré-RES-104, reservas via chat/IA, e qualquer caminho futuro que esqueça de preencher.

## Checklist de validação

- [ ] Reserva antiga (com `tipo_quarto = NULL` no banco) → detalhe exibe nome da categoria
- [ ] Reserva criada pelo chat/IA → detalhe exibe nome da categoria
- [ ] Reserva nova com `tipo_quarto` preenchido → detalhe continua exibindo o valor gravado (sem regressão)
- [ ] Lista (`/usuarios/reservas`) continua igual