### PR TITLE
🐛(fix): chat herda user_id de sessão anterior — RES-108

### DIFF
--- a/Backend/src/controllers/chat.controller.ts
+++ b/Backend/src/controllers/chat.controller.ts
@@ -79,14 +79,21 @@ async function getOrCreateAppSession(
   );
 
   if (rows[0]) {
-    if (!isSessionActive(rows[0].atualizado_em)) {
-      // Sessão expirada: fechar e criar nova
+    // Troca de identidade entre logins no mesmo deviceId (logout, ou login com
+    // outra conta) precisa abandonar a sessão antiga: o `deviceId` vive no
+    // SharedPreferences do Flutter e não muda, então sem isso o user_id antigo
+    // permaneceria gravado e o chat deslogado herdaria a identidade do user
+    // anterior — fazendo o Bene pular a coleta de nome/email/telefone (RES-108).
+    // Login no meio de uma sessão anônima (null → user) continua enriquecendo.
+    const identityChanged = rows[0].user_id !== null && rows[0].user_id !== userId;
+
+    if (identityChanged || !isSessionActive(rows[0].atualizado_em)) {
       await masterPool.query(
         `UPDATE sessao_chat SET status = 'FECHADA', atualizado_em = NOW() WHERE id = $1`,
         [rows[0].id],
       );
     } else {
-      // Sessão ativa: reutilizar. Enriquecer com userId se necessário.
+      // Sessão ativa, mesma identidade: reutilizar. Enriquecer com userId se necessário.
       if (userId && !rows[0].user_id) {
         await masterPool.query(
           `UPDATE sessao_chat SET user_id = $2, atualizado_em = NOW() WHERE id = $1`,


### PR DESCRIPTION
## O que foi feito

Conserto do vazamento de identidade entre logins na sessão de chat in-app. Em `Backend/src/controllers/chat.controller.ts`, dentro de `getOrCreateAppSession`, agora comparamos o `user_id` salvo na sessão aberta com o `userId` extraído do JWT da request. Se divergirem (logout — sessão tinha user_id e request veio sem; ou troca de conta — user_id diferente), fechamos a sessão antiga (`status = 'FECHADA'`) e caímos no `INSERT` de uma nova. Login no meio de uma sessão anônima (`null → user`) continua sendo enriquecimento, sem regressão.

Issue: [RES-108](https://linear.app/reservaqui/issue/RES-108)

## Por que era um problema

`deviceId` é persistido em `SharedPreferences` do Flutter (`Frontend/lib/features/chat/presentation/providers/chat_provider.dart:55-66`) e não muda no logout. Antes do fix, a lógica de enriquecimento só preenchia `user_id` quando estava vazio — nunca limpava. Resultado: o chat deslogado herdava o `user_id` do último usuário logado no mesmo dispositivo. O `AgentOrchestratorService` (em `agentOrchestrator.service.ts:252`) injetava no prompt `Usuário Autenticado: SIM` e o Bene pulava a coleta de nome/email/telefone. O LLM acabava chamando `criar_reserva` com `walkInNome="Seu Nome"` (alucinado a partir do schema da tool) e o fallback do RES-103 em `_createReservaUsuario` não disparava (`!nomeHospede` era falso), gravando lixo na reserva.

## Casos cobertos

| Sessão | Request | Ação | Por quê |
| -- | -- | -- | -- |
| `user_id='a'` | `user_id='a'` | reutiliza | mesmo usuário logado |
| `user_id=null` | `user_id=null` | reutiliza | fluxo anônimo contínuo |
| `user_id=null` | `user_id='a'` | reutiliza + enriquece | login no meio da sessão |
| `user_id='a'` | `user_id=null` | **fecha + nova** | logout (era o bug) |
| `user_id='a'` | `user_id='b'` | **fecha + nova** | troca de conta no mesmo device |

## Arquivos modificados

- `Backend/src/controllers/chat.controller.ts` — adiciona a checagem `identityChanged` antes de decidir reutilizar a sessão, e estende a condição de fechamento.

## Limpeza pós-deploy (manual)

- Fechar (`UPDATE sessao_chat SET status='FECHADA'`) sessões abertas antes do deploy, pra evitar que devices em uso reaproveitem sessão envenenada.
- Corrigir/remover reservas-lixo já criadas (`nome_hospede='Seu Nome'`, demais campos NULL) no schema do hotel afetado.

## Test plan

- [ ] Logar como user → reservar pela tela → deslogar → abrir chat → Bene pergunta NOME, EMAIL e TELEFONE antes de criar
- [ ] Reserva criada pelo chat deslogado grava `nome_hospede / email_hospede / telefone_contato` corretos
- [ ] Logar no meio do chat (anônimo → autenticado) continua enriquecendo o `user_id` na mesma sessão
- [ ] Reservar pelo chat logado continua usando o perfil sem perguntar de novo (RES-103 intacto)

🤖 Generated with [Claude Code](https://claude.com/claude-code)