### PR TITLE
🐛(fix): limpar description do walkInEmail — RES-109

### DIFF
--- a/Backend/src/services/ai/tools.ts
+++ b/Backend/src/services/ai/tools.ts
@@ -146,7 +146,7 @@ export const buildAgentTools = (context: ChatContext | null) => {
         dataCheckin: z.string().describe('Data de check-in (formato YYYY-MM-DD).'),
         dataCheckout: z.string().describe('Data de check-out (formato YYYY-MM-DD).'),
         walkInNome: z.string().optional().describe('Nome completo do hóspede. OBRIGATÓRIO se o usuário não estiver logado.'),
-        walkInEmail: z.string().optional().describe('Email do hóspede. OBRIGATÓRIO se o usuário não estiver logado. Deve ser um endereço válido no formato nome@dominio.com — nunca passe a palavra "email" literalmente, sempre o endereço real informado pelo usuário. Será usado para enviar a confirmação e o link de pagamento.'),
+        walkInEmail: z.string().optional().describe('Email do hóspede. OBRIGATÓRIO se o usuário não estiver logado. Será usado para enviar a confirmação e o link de pagamento.'),
         walkInTelefone: z.string().optional().describe('Telefone ou WhatsApp do hóspede (apenas números). OBRIGATÓRIO se o usuário não estiver logado.'),
       }),
     }


### PR DESCRIPTION
## O que foi feito

Reverter a `describe()` do parâmetro `walkInEmail` da tool `criar_reserva` (`Backend/src/services/ai/tools.ts`) à versão pré-RES-99. Remove o exemplo concreto `nome@dominio.com` e a advertência negativa `nunca passe a palavra "email" literalmente` — os dois empurravam o LLM a chutar placeholders genéricos (`seu_email@example.com`, `Seu Nome`) em vez de perguntar os dados ao usuário.

Issue: [RES-109](https://linear.app/reservaqui/issue/RES-109)

## Por que era um problema

Depois do merge do RES-108 (que fechou o vazamento de identidade entre logins), o Bene passou a cair corretamente no caminho walk-in quando o usuário está deslogado. Só que, em vez de perguntar nome/email/telefone, ele estava chamando `criar_reserva` com:

```
nome_hospede = "Seu Nome"
email_hospede = "seu_email@example.com"
```

Antes do RES-99 (commit `a394a1c`, ontem 11:01), esse mesmo fluxo funcionava — pelo chat in-app, pelo WhatsApp e por áudio. O Bene perguntava, recebia a resposta e usava o valor literal.

Dois mecanismos contaminaram o comportamento:

1. **Exemplo concreto na description vira template** — mesmo padrão atacado pelo RES-97 no `selecionar_hotel`. `nome@dominio.com` no schema → o LLM gera `seu_email@example.com` (domínio reservado pra exemplo, mais frequente no pré-treino).
2. **Negação reforça o token negado** — "nunca passe a palavra 'email' literalmente" mantém o token "email" em destaque no campo. E como o LLM lê o schema da tool como um bloco, a contaminação transbordou pro `walkInNome` ao lado, gerando "Seu Nome".

A validação de formato em runtime (linhas 112-114 do handler, introduzida pelo hotfix `7c1bd2b`) é genérica (`/^[^\s@]+@[^\s@]+\.[^\s@]+$/`), não contém exemplo concreto, e continua barrando o caso original que motivou o RES-99 (LLM passando a palavra `"email"` sem `@`). Por isso foi mantida.

## Diff

```diff
- walkInEmail: z.string().optional().describe('Email do hóspede. OBRIGATÓRIO se o usuário não estiver logado. Deve ser um endereço válido no formato nome@dominio.com — nunca passe a palavra "email" literalmente, sempre o endereço real informado pelo usuário. Será usado para enviar a confirmação e o link de pagamento.'),
+ walkInEmail: z.string().optional().describe('Email do hóspede. OBRIGATÓRIO se o usuário não estiver logado. Será usado para enviar a confirmação e o link de pagamento.'),
```

## Test plan

- [ ] Reservar pelo chat deslogado: Bene pergunta NOME, EMAIL e TELEFONE
- [ ] Valores informados pelo usuário (ex.: `João Silva`, `joao@gmail.com`, `11999998888`) são gravados literalmente em `nome_hospede / email_hospede / telefone_contato`
- [ ] Email de confirmação chega na caixa real do usuário
- [ ] Mesmo fluxo funciona pelo WhatsApp e pelo áudio (sem regressão)
- [ ] Validação runtime continua barrando `"email"` literal (sem `@`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)