### PR TITLE
🐛(fix): endurecer criar_reserva contra alucinação intermitente (placeholders + data) — RES-110

### DIFF
--- a/Backend/src/services/ai/agentOrchestrator.service.ts
+++ b/Backend/src/services/ai/agentOrchestrator.service.ts
@@ -238,6 +238,7 @@ Regras obrigatórias para ferramentas:
 - Se uma ferramenta retornar "ERRO CRÍTICO", NÃO diga ao usuário que a reserva foi criada. Informe que houve um problema e peça para tentar novamente.
 - MÁXIMA IMPORTÂNCIA: Após receber os dados de uma ferramenta (como buscar_hoteis ou checar_disponibilidade), você DEVE parar de usar ferramentas e responder ao usuário traduzindo o JSON recebido em uma lista clara, amigável e direta. NUNCA DEVOLVA RESPOSTA VAZIA.
 - Após criar reserva com sucesso, SEMPRE informe o código público da reserva ao usuário.
+- Ao chamar criar_reserva, copie LITERALMENTE o nome, email e telefone que o usuário acabou de digitar nesta conversa. Se algum desses três não foi informado ainda, faça UMA pergunta amigável e espere a resposta — não chame a tool até ter os três valores reais.
 </tool_governance>
 ${ragSection}
 Regras de Fluxo:
@@ -329,17 +330,25 @@ Estado Atual:
 
   private static get BASE_SYSTEM_PROMPT(): string {
     const now = new Date();
-    const today = now.toLocaleDateString('pt-BR', {
+    const todayBR = now.toLocaleDateString('pt-BR', {
       weekday: 'long',
       day: '2-digit',
       month: '2-digit',
       year: 'numeric',
       timeZone: 'America/Sao_Paulo',
     });
+    // en-CA retorna YYYY-MM-DD nativo — é o formato que as tools esperam.
+    // Dar a versão ISO direto evita o LLM ter que converter de pt-BR e errar
+    // ano/mês (especialmente em "amanhã", "sexta", "dia 20").
+    const todayIso = now.toLocaleDateString('en-CA', {
+      year: 'numeric', month: '2-digit', day: '2-digit',
+      timeZone: 'America/Sao_Paulo',
+    });
     return `
 Você é Bene, o assistente virtual de atendimento da ReservAqui.
 
-DATA DE HOJE: ${today}
+DATA DE HOJE: ${todayBR} (formato ISO: ${todayIso})
+Ao passar datas para qualquer tool, use SEMPRE o formato YYYY-MM-DD. Calcule deslocamentos ("amanhã" = ISO + 1 dia) a partir do valor ISO acima — não invente o ano nem o mês.
 Use esta data como referência ao interpretar expressões como "hoje", "amanhã", "essa semana", "esse fim de semana", etc.
 
 Sua missão é atender hóspedes com rapidez, cordialidade e precisão, simulando um concierge brasileiro: acolhedor, profissional, prestativo e objetivo.

--- a/Backend/src/services/ai/tools.ts
+++ b/Backend/src/services/ai/tools.ts
@@ -113,6 +113,31 @@ export const buildAgentTools = (context: ChatContext | null) => {
         return `ERRO DE VALIDAÇÃO: "${walkInEmail}" não é um email válido. Pergunte o endereço de email completo (formato nome@dominio.com) e chame a tool novamente com o valor correto.`;
       }
 
+      // Placeholders inequívocos que só vêm de alucinação do LLM (nunca de um
+      // usuário real digitando). Lista curta e literal pra zero falso-positivo —
+      // "Teste Silva" e "email@teste.com.br" passam sem problema.
+      const emailLower = walkInEmail?.toLowerCase().trim();
+      const nomeLower  = walkInNome?.toLowerCase().trim();
+      const emailPlaceholders = new Set([
+        'seu_email@example.com',  'seuemail@example.com',
+        'seu_email@dominio.com',  'seuemail@dominio.com',
+        'nome@dominio.com',       'nome@example.com',
+        'email@example.com',      'usuario@example.com',
+        'exemplo@example.com',    'fulano@example.com',
+      ]);
+      const nomePlaceholders = new Set([
+        'seu nome', 'meu nome', 'nome completo',
+        'nome do hospede', 'nome do hóspede',
+        'fulano', 'fulano de tal',
+        'hospede', 'hóspede', 'guest',
+      ]);
+      if (emailLower && emailPlaceholders.has(emailLower)) {
+        return `ERRO DE VALIDAÇÃO: "${walkInEmail}" é um placeholder, não o email real do hóspede. Pergunte ao usuário o email dele e chame a tool de novo com o valor literal que ele informar.`;
+      }
+      if (nomeLower && nomePlaceholders.has(nomeLower)) {
+        return `ERRO DE VALIDAÇÃO: "${walkInNome}" é um placeholder, não o nome real do hóspede. Pergunte ao usuário o nome completo dele e chame a tool de novo com o valor literal que ele informar.`;
+      }
+
       try {
         const reserva = await createReservaChat({
           hotel_id:       context.hotelId,


### PR DESCRIPTION
## O que foi feito

Três defesas pequenas e independentes contra a alucinação intermitente do Bene ao criar reserva pelo chat deslogado. Mesmo após RES-108 e RES-109, o LLM continuava ocasionalmente pulando a coleta de nome/email/telefone e chamando \`criar_reserva\` com placeholders (\"Seu Nome\", \"seu_email@example.com\"), ou errando ano/mês em datas relativas (\"amanhã\", \"sexta\").

Issue: [RES-110](https://linear.app/reservaqui/issue/RES-110)

## Mudanças

### 1. \`Backend/src/services/ai/tools.ts\` — blacklist literal de placeholders

Depois da validação de formato do email, o handler do \`criar_reserva\` checa o valor recebido contra dois \`Set\`s de strings que **só vêm de alucinação** do LLM:

- emails: \`seu_email@example.com\`, \`seuemail@example.com\`, \`seu_email@dominio.com\`, \`seuemail@dominio.com\`, \`nome@dominio.com\`, \`nome@example.com\`, \`email@example.com\`, \`usuario@example.com\`, \`exemplo@example.com\`, \`fulano@example.com\`
- nomes: \`seu nome\`, \`meu nome\`, \`nome completo\`, \`nome do hospede\`, \`nome do hóspede\`, \`fulano\`, \`fulano de tal\`, \`hospede\`, \`hóspede\`, \`guest\`

Comparação literal (lowercase + trim). **Zero falso-positivo** — \`Teste Silva\`, \`email@teste.com.br\`, \`Maria José da Silva\` passam sem encostar nessa lista. Quando bate, devolve \`ERRO DE VALIDAÇÃO\` orientando o bot a perguntar o valor real.

### 2. \`Backend/src/services/ai/agentOrchestrator.service.ts\` — regra positiva no \`<tool_governance>\`

Linha nova:

> Ao chamar criar_reserva, copie LITERALMENTE o nome, email e telefone que o usuário acabou de digitar nesta conversa. Se algum desses três não foi informado ainda, faça UMA pergunta amigável e espere a resposta — não chame a tool até ter os três valores reais.

Regra positiva, sem negação e sem exemplo concreto (evita o anti-pattern que originou RES-99 → RES-109).

### 3. \`Backend/src/services/ai/agentOrchestrator.service.ts\` — data ISO no \`BASE_SYSTEM_PROMPT\`

Antes:
\`\`\`
DATA DE HOJE: terça-feira, 15/05/2026
\`\`\`

Depois:
\`\`\`
DATA DE HOJE: terça-feira, 15/05/2026 (formato ISO: 2026-05-15)
Ao passar datas para qualquer tool, use SEMPRE o formato YYYY-MM-DD. Calcule deslocamentos (\"amanhã\" = ISO + 1 dia) a partir do valor ISO acima — não invente o ano nem o mês.
\`\`\`

\`toLocaleDateString('en-CA', { timeZone: 'America/Sao_Paulo' })\` retorna \`YYYY-MM-DD\` nativo, sem parsing manual. \`timeZone\` continua \`America/Sao_Paulo\`, então independe do \`TZ\` do servidor (que no servidor do professor está ajustado pra UTC-3).

## Por que não usar regex genérico

Tentado e descartado. Qualquer regex tipo \"nome precisa ter sobrenome\" ou \"email não pode ter 'teste'\" derruba usuários reais — apresentações, bancada de testes, e até nomes legítimos sem sobrenome. A blacklist literal acerta exatamente os placeholders que vimos no log e nada mais.

## Test plan

- [ ] Reserva pelo chat deslogado: Bene pergunta nome/email/telefone e usa os valores literais informados
- [ ] LLM tentando passar \`walkInEmail=\"seu_email@example.com\"\` recebe ERRO DE VALIDAÇÃO e refaz a pergunta
- [ ] LLM tentando passar \`walkInNome=\"Seu Nome\"\` recebe ERRO DE VALIDAÇÃO e refaz a pergunta
- [ ] Datas relativas (\"amanhã\", \"sexta\", \"dia 20\") interpretadas corretamente em SP TZ
- [ ] Dados reais (\`Teste Silva\`, \`email@teste.com.br\`, \`Maria José\`) continuam aceitos
- [ ] Fluxo do chat logado (RES-103) intacto

🤖 Generated with [Claude Code](https://claude.com/claude-code)