### PR TITLE
🐛(fix): resolver hotel pelo histórico no handleReserva — RES-111

### DIFF
--- a/Backend/src/services/ai/agentOrchestrator.service.ts
+++ b/Backend/src/services/ai/agentOrchestrator.service.ts
@@ -173,6 +173,21 @@ ${ragContext}
   }
 
   private static async handleReserva(userMessage: string, context: ChatContext, history: any[]): Promise<string> {
+    // Resolve hotel pelo histórico recente quando a sessão ainda não está travada —
+    // simétrico ao handleDuvida. Sem isso, o LLM tenta chutar o UUID em
+    // selecionar_hotel a partir do texto do histórico (os UUIDs do buscar_hoteis
+    // não voltam no getChatHistory, que só carrega texto puro) e o Groq rejeita
+    // por pattern mismatch — tool_use_failed em cascata por todas as chaves do
+    // round-robin (RES-111).
+    if (!context.hotelId) {
+      const resolved = await this.tryResolveHotelFromHistory(context.sessionId, history);
+      if (resolved) {
+        context.hotelId = resolved.hotelId;
+        context.schemaName = resolved.schemaName;
+        console.log(`[AgentOrchestrator] Hotel resolvido pelo histórico (RESERVA): ${resolved.hotelId}`);
+      }
+    }
+
     const tools = buildAgentTools(context);
     const cidadesDisponiveis = await this.getCidadesDisponiveis();
 


### PR DESCRIPTION
## O que foi feito

Adicionar a chamada de \`tryResolveHotelFromHistory\` no início do \`handleReserva\` em \`Backend/src/services/ai/agentOrchestrator.service.ts\` — mesma chamada que já existia no \`handleDuvida\`. Quando \`context.hotelId\` está null e o texto recente da conversa cita o nome de um hotel cadastrado, o método busca por \`position(LOWER(nome_hotel) IN LOWER(\$1))\` na tabela \`anfitriao\` e popula \`context.hotelId\` + \`context.schemaName\` antes do LLM ser chamado.

Issue: [RES-111](https://linear.app/reservaqui/issue/RES-111)

## Por que era um problema

Já na primeira interação após uma busca de hotéis, o segundo turno do chat quebrava com:

\`\`\`
tool_use_failed: parameters for tool selecionar_hotel did not match schema:
errors: [\`/hotelIdSelecionado\`: does not match pattern '^([0-9a-fA-F]{8}-...UUID...)\$']
failed_generation: '<function=selecionar_hotel>{\"hotelIdSelecionado\": \"Quarto Familia Gaudério\"}</function>'
\`\`\`

E \`llmFactory\` cascateava em todas as chaves do round-robin (\`groq falhou (chave 1/5)\` × 4) — payload inválido falha em qualquer chave, então o fallback só queima cota.

A causa raiz é assimetria entre os handlers: o método \`tryResolveHotelFromHistory\` (linha 415-449) já existia, mas só era invocado em \`handleDuvida:97-105\`. No caminho RESERVA — que é exatamente onde mora o \`selecionar_hotel\` — o método nunca era chamado.

Sequência do bug:

1. Turno 1: usuário pede hotéis em SP, bot chama \`buscar_hoteis(uf='SP')\`, a tool retorna JSON com \`hotel_id\` (UUID) + \`nome_hotel\`.
2. Bot responde em texto pro usuário citando os nomes.
3. \`persistMessage\` salva só \`origem\` + \`conteudo\` na \`mensagem_chat\` — a \`ToolMessage\` com os UUIDs é descartada.
4. \`selecionar_hotel\` nunca foi chamado, então \`sessao_chat.hotel_id\` continua NULL.
5. Turno 2: \`getChatHistory\` traz só texto. \`context.hotelId\` continua NULL. O LLM tem o nome do hotel no texto mas nenhum UUID — chuta o que parece um identificador (às vezes pega o nome de uma categoria de quarto que aparecia na sugestão), e o Groq rejeita.

## Fix aplicado

5 linhas dentro de um \`if\`, no início do \`handleReserva\`:

\`\`\`ts
if (!context.hotelId) {
  const resolved = await this.tryResolveHotelFromHistory(context.sessionId, history);
  if (resolved) {
    context.hotelId = resolved.hotelId;
    context.schemaName = resolved.schemaName;
    console.log(\`[AgentOrchestrator] Hotel resolvido pelo histórico (RESERVA): \${resolved.hotelId}\`);
  }
}
\`\`\`

Quando bate, o \`<reservation_mode>\` passa a injetar \`Hotel Selecionado: SIM\` e o LLM pula \`selecionar_hotel\`, indo direto pra \`checar_disponibilidade\`. Sem mudança no método chamado, no SQL ou no prompt — só simetria com o caminho de dúvida.

## Test plan

- [ ] Turno 1: usuário pede hotéis em uma cidade, bot lista opções
- [ ] Turno 2: \"esse mesmo, dia X a Y\" → bot resolve o hotel pelo nome no histórico e vai direto pra checar disponibilidade, sem \`tool_use_failed\`
- [ ] Log mostra \`[AgentOrchestrator] Hotel resolvido pelo histórico (RESERVA): <uuid>\` quando o nome do hotel está em alguma das últimas 6 mensagens
- [ ] Fluxo com hotel selecionado explicitamente (happy path do RES-108) continua igual
- [ ] Quando o histórico não menciona nenhum hotel cadastrado, o comportamento continua sendo o atual (LLM faz \`buscar_hoteis\` primeiro)

🤖 Generated with [Claude Code](https://claude.com/claude-code)